### PR TITLE
Prepare v0.2.0 legacy repository polish release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## v0.2.0 - 2026-06-08
+
+### Added
+- Added MIT license.
+- Added `.gitignore` entries for large genomics input, intermediate, and output files.
+- Added `docs/roadmap.md` describing the path toward a production-grade pipeline.
+
+### Changed
+- Clarified that this repository currently provides a legacy/minimal Slurm-based Micro-C preprocessing script rather than a modern restartable workflow manager pipeline.
+- Updated README documentation to match the current repository contents, inputs, outputs, requirements, and limitations.
+- Made `mdp.sh` safer for public use by using stricter shell behavior, checking required commands, using configurable thread count from `SLURM_CPUS_PER_TASK`, and removing in-script software installation.
+- Improved FASTA index and chromosome sizes handling in `mdp.sh`.
+- Improved argument parsing and error handling in `get_qc.py`.
+
+### Notes
+- This release preserves the legacy single-sample script model.
+- Restartable chunk-based processing is planned for a future milestone and should not be treated as part of v0.2.0.

--- a/README.md
+++ b/README.md
@@ -129,4 +129,6 @@ You can rerun that command manually after a completed or partially completed run
 
 ## Version note
 
-Legacy script version history is retained in comments at the bottom of `mdp.sh`. This README does not assign a separate release version.
+Legacy script version history is retained in comments at the bottom of `mdp.sh`. Repository-level release history is tracked in `CHANGELOG.md`.
+
+The `v0.2.0` release is a repository-polish release for the legacy/minimal Slurm workflow. It does not make this repository a fully restartable workflow manager pipeline.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -94,9 +94,9 @@ Planned or completed tasks:
 - [x] Remove in-script software installation.
 - [x] Improve FASTA index and chromosome sizes handling.
 - [x] Improve `get_qc.py` argument parsing and error handling.
-- [ ] Add a license file.
-- [ ] Update README after license addition.
-- [ ] Add a changelog.
+- [x] Add a license file.
+- [x] Update README after license addition.
+- [x] Add a changelog.
 
 Expected status after this milestone:
 


### PR DESCRIPTION
### Motivation
- Prepare the repository for the `v0.2.0` legacy/minimal Slurm polish release by making the public surface consistent, safe to inspect, and easier to understand.
- Ensure release artifacts and documentation exist for repository-level history without converting the project into a modern workflow-manager pipeline.

### Description
- Added `CHANGELOG.md` with a `v0.2.0` entry dated `2026-06-08` that summarizes added and changed items and notes the legacy single-sample model.
- Updated the README `Version note` so that script history is retained in `mdp.sh` comments and repository-level history is tracked in `CHANGELOG.md`, and clarified that `v0.2.0` is a repository-polish release.
- Marked the `v0.2.0` checklist items in `docs/roadmap.md` as completed for license, README update, and changelog. 
- Audited release-blocking items in `mdp.sh` and `get_qc.py` and confirmed they meet the milestone requirements (strict shell options, dependency checks, `THREADS` from `SLURM_CPUS_PER_TASK`, safe FASTA/.fai handling, `argparse` and robust stats parsing) without broad refactors. 

### Testing
- Ran `bash -n mdp.sh` and it reported no syntax errors. 
- Ran `python3 -m py_compile get_qc.py` and compilation succeeded. 
- Verified `python3 get_qc.py --help` prints usage and `python3 get_qc.py -p /tmp/microc_pairtools_stats_test.txt` on a synthetic stats file produced the expected QC table. 
- Confirmed `.gitignore` excludes large genomics inputs/outputs and `LICENSE` contains the MIT text for the repository owner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2662b50368832795f0cf394d948163)