### PR TITLE
Prepare v0.3.0 project structure and identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
-## v0.2.0 - 2026-06-08
+## v0.3.0 - Unreleased
+
+### Added
+- Added planning documentation for the future project design, expected outputs, configuration area, and examples area.
+- Documented the current engine decision status: `mdp.sh` remains the retained legacy script, while Bash-first, Snakemake, and Nextflow remain candidate future directions.
+
+### Changed
+- Updated README repository contents and project identity language for the next public-facing milestone.
+- Updated the roadmap to reflect completed v0.3.0 project structure and identity work without marking future engine implementation tasks complete.
+
+### Notes
+- The modern production-facing pipeline engine is planned but not implemented in this milestone.
+- Restartable chunk-based execution, sample-sheet execution, containers, CI, and full QC reports remain future work.
+
+## v0.2.0 milestone - not tagged
 
 ### Added
 - Added MIT license.
@@ -17,5 +31,7 @@ All notable changes to this project will be documented in this file.
 - Improved argument parsing and error handling in `get_qc.py`.
 
 ### Notes
-- This release preserves the legacy single-sample script model.
+- This was an internal cleanup milestone before active `v0.3.0` development.
+- No Git tag or GitHub Release was created for this milestone.
+- This milestone preserves the legacy single-sample script model.
 - Restartable chunk-based processing is planned for a future milestone and should not be treated as part of v0.2.0.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # microC-pipeline
 
-`microC-pipeline` is a legacy/minimal Slurm-based Micro-C preprocessing workflow. The repository is intentionally small and centers on one shell script, `mdp.sh`, plus a lightweight Pairtools-stats summarizer, `get_qc.py`.
+`microC-pipeline` currently contains a legacy/minimal Slurm-based Micro-C preprocessing workflow. The repository is being prepared for future development toward a production-facing pipeline, but the modern engine is planned only and is not implemented yet.
 
-Active, restartable development has moved to **HiC-Nap**. This repository is retained as a compact legacy workflow for users who want a simple Slurm script that can be inspected and adapted for an HPC site.
+The retained runnable workflow centers on one shell script, `mdp.sh`, plus a lightweight Pairtools-stats summarizer, `get_qc.py`. Users should not expect restartable chunk-based execution, sample-sheet orchestration, containers, or a packaged workflow-manager pipeline from the current code.
 
 ## What this repository does
 
@@ -18,14 +18,22 @@ For a single sample, `mdp.sh` runs a classic Micro-C preprocessing path:
 8. `.pairs.gz`, `.cool`, and `.mcool` generation with Pairix and Cooler.
 9. A small text QC summary from Pairtools stats using `get_qc.py`.
 
-This is **not** a modern, restartable workflow manager pipeline. It does not include sample-sheet orchestration, containers, continuous integration, or a packaged software environment.
+This is **not** a modern, restartable workflow manager pipeline. It does not include restartable chunk-based execution, sample-sheet orchestration, containers, continuous integration, full QC reports, or a packaged software environment.
 
 ## Repository contents
 
 ```text
-README.md   Project overview and usage notes
-mdp.sh      Legacy/minimal Slurm Micro-C preprocessing script
-get_qc.py   Small Pairtools-stats QC text summarizer
+README.md           Project overview and usage notes
+mdp.sh              Legacy/minimal Slurm Micro-C preprocessing script
+get_qc.py           Small Pairtools-stats QC text summarizer
+CHANGELOG.md        Repository-level change history
+LICENSE             MIT license
+docs/roadmap.md     Development roadmap toward a production-grade pipeline
+docs/design.md      Planning notes for future pipeline design
+docs/outputs.md     Current and planned output documentation notes
+config/README.md    Placeholder for future configuration examples
+examples/README.md  Placeholder for future tiny synthetic examples
+.gitignore          Ignore rules for large genomics outputs and local files
 ```
 
 ## Expected input and output layout
@@ -121,6 +129,8 @@ You can rerun that command manually after a completed or partially completed run
 ## Notes and limitations
 
 - This is a legacy/minimal Slurm script, not a fully restartable production workflow.
+- The repository is being prepared for future development, but the future production-facing pipeline is not implemented yet.
+- Restartable chunk-based execution is not available in the current code.
 - Paths and FASTQ naming are intentionally simple and historical.
 - Intermediate files may be removed after downstream files are created, matching the previous script behavior.
 - Module names and dependency installation are intentionally left to each HPC site.
@@ -131,4 +141,4 @@ You can rerun that command manually after a completed or partially completed run
 
 Legacy script version history is retained in comments at the bottom of `mdp.sh`. Repository-level release history is tracked in `CHANGELOG.md`.
 
-The `v0.2.0` release is a repository-polish release for the legacy/minimal Slurm workflow. It does not make this repository a fully restartable workflow manager pipeline.
+The `v0.2.0` milestone was an internal, untagged repository-polish milestone for the legacy/minimal Slurm workflow. The next public-facing milestone is `v0.3.0`, focused on project structure and identity. It does not make this repository a fully restartable workflow manager pipeline.

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,7 @@
+# Configuration directory
+
+This directory is reserved for future configuration examples and schemas.
+
+No modern config-driven runner is implemented yet. The current runnable workflow is still `mdp.sh`, which accepts command-line arguments and uses the legacy FASTQ layout described in `README.md`.
+
+Future configuration work may define sample metadata, FASTQ paths, genome resources, output options, threading, and QC settings.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,26 @@
+# Design notes
+
+This document records current design assumptions for `microC-pipeline` as the repository is prepared for the `v0.3.0` project-structure milestone.
+
+## Current implementation status
+
+- `mdp.sh` remains the retained legacy/minimal Slurm script.
+- The current runnable workflow is single-sample oriented and uses historical FASTQ naming assumptions.
+- The modern production-facing pipeline engine is not implemented yet.
+- Restartable chunk-based execution is not available in the current repository.
+
+## Engine direction planning note
+
+No final engine choice has been made for the future production-facing workflow.
+
+Candidate future directions include:
+
+- **Bash-first**: keep the implementation close to the existing script while adding stronger structure, validation, and restart behavior.
+- **Snakemake**: use a rule-based workflow manager with explicit inputs, outputs, and cluster execution support.
+- **Nextflow**: use a process-based workflow manager with strong portability patterns for local, HPC, and containerized execution.
+
+HiC-Nap restartable chunk-processing concepts are expected to inform future development, especially FASTQ chunking, per-chunk status tracking, conservative restart behavior, global merge/deduplication, and progress logging. Those concepts are planning inputs only in this repository today; they are not implemented here yet.
+
+## Near-term design boundaries
+
+The `v0.3.0` milestone is limited to project identity and lightweight structure. It should not add the modern engine, sample-sheet execution, workflow-manager files, containers, CI, or full QC reports.

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -1,0 +1,34 @@
+# Output notes
+
+This document describes current legacy outputs and planned future output organization. It is a planning document, not a guarantee that the modern output layout has been implemented.
+
+## Current legacy outputs
+
+The retained `mdp.sh` workflow writes outputs and intermediates into repository-root directories such as:
+
+```text
+BAM/
+cool/
+fastqc/
+hic/
+genome/
+pairs/
+stats/
+temp/
+logs/
+```
+
+These paths reflect the legacy/minimal Slurm workflow and may include intermediates that are removed after downstream products are created.
+
+## Planned future output direction
+
+A future production-facing pipeline should make final, temporary, and diagnostic outputs explicit. A candidate future layout is documented in `docs/roadmap.md`, but it is not implemented yet.
+
+Expected future documentation should define:
+
+- final contact-pair outputs and indexes
+- contact matrix outputs
+- optional BAM retention
+- run metadata
+- QC tables, JSON, and reports
+- temporary files and cleanup behavior

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -108,16 +108,25 @@ microC-pipeline is public-safe and useful as a documented legacy Slurm script.
 
 Goal: prepare the repository for active development toward v1.0.0.
 
-Planned tasks:
+Completed project structure and identity tasks:
 
-- Add `CHANGELOG.md`.
-- Add `docs/` with design notes and output specifications.
-- Move the current `mdp.sh` into `legacy/` or explicitly label it as legacy in place.
-- Add a modern entrypoint plan, for example `bin/microc-pipeline`.
-- Add `config/` examples.
-- Add `examples/` with tiny synthetic or documented toy inputs.
-- Define repository topics and description on GitHub.
-- Decide whether the main engine will be Bash-first, Snakemake, or Nextflow.
+- [x] Add a `v0.3.0 - Unreleased` changelog section.
+- [x] Add `docs/design.md` with design notes and engine-decision status.
+- [x] Add `docs/outputs.md` with current legacy output notes and planned output-documentation direction.
+- [x] Explicitly label `mdp.sh` as the retained legacy/minimal Slurm script in public-facing documentation.
+- [x] Add `config/README.md` as a placeholder for future configuration examples and schemas.
+- [x] Add `examples/README.md` as a placeholder for future tiny synthetic examples.
+- [x] Document that Bash-first, Snakemake, and Nextflow remain candidate future engine directions.
+- [x] Document that HiC-Nap restartable chunk-processing concepts are planning inputs for future development.
+
+Remaining or future tasks, not completed in this milestone:
+
+- [ ] Add a modern executable entrypoint, for example `bin/microc-pipeline`.
+- [ ] Define GitHub repository topics and description.
+- [ ] Make a final production engine choice if project ownership gives that direction.
+- [ ] Implement the modern pipeline engine.
+- [ ] Implement restartable chunk-based execution.
+- [ ] Implement sample-sheet execution, workflow-manager files, containers, CI, or full QC reports.
 
 Expected status after this milestone:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+# Examples directory
+
+This directory is reserved for future examples.
+
+No real sample data is included. Future examples should be tiny, synthetic, and clearly documented so the repository stays small and does not accidentally include large genomics files.
+
+The current runnable example remains the `sbatch mdp.sh <SAMPLE_ID> <GENOME_NAME> <GENOME_FASTA>` command documented in `README.md`.


### PR DESCRIPTION
### Motivation
- Prepare the repository for the `v0.3.0` milestone by clarifying project identity and adding lightweight planning artifacts without implementing a modern pipeline engine or restartable chunk processing.
- Keep the retained legacy `mdp.sh` runnable while making the repository explicit about its limitations and future direction.

### Description
- Add a `v0.3.0 - Unreleased` section to `CHANGELOG.md` and revise the `v0.2.0` entry to state it was an internal, untagged milestone with no Git tag or GitHub Release. 
- Update `README.md` to list the current public-facing repository contents, to label the code as a legacy/minimal Slurm workflow, and to clearly state that restartable chunk-based execution and a modern engine are planned but not implemented. 
- Add planning placeholders `docs/design.md`, `docs/outputs.md`, `config/README.md`, and `examples/README.md` that document design assumptions, output expectations, and reserved locations for future configuration and examples without adding data or pretending features exist. 
- Update `docs/roadmap.md` to mark only the v0.3.0 project-structure and identity tasks completed and leave future engine and restartability work as unfinished. 

### Testing
- Verified shell syntax with `bash -n mdp.sh`, which completed successfully. 
- Verified Python syntax with `python3 -m py_compile get_qc.py`, which completed successfully. 
- Verified CLI help with `python3 get_qc.py --help`, which printed usage and completed successfully. 
- Ran `git diff --check` which reported no whitespace or diff issues, and attempted `markdownlint` but it is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2664e581bc8327878e1dd5f1d0c391)