### PR TITLE
Implement v0.4.0 config-driven single-sample Micro-C workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ logs/
 __pycache__/
 *.pyc
 .DS_Store
+results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.4.0 - Unreleased
+
+### Added
+- Added a config-driven single-sample Micro-C runner at `bin/microc-pipeline`.
+- Added `config/example.single-sample.yaml` as an example single-sample YAML config without restriction enzyme settings.
+- Added config validation for required fields, value types, unsupported assay values, and missing input files.
+- Added dry-run mode to print planned commands without running external tools.
+- Added per-sample output directory handling under `output_dir/sample`.
+- Added structured `run_metadata.json` output for real runs.
+- Added `docs/configuration.md` for the v0.4.0 config format and runner behavior.
+
+### Changed
+- Updated README, design notes, output documentation, roadmap, and configuration directory notes for the v0.4.0 single-sample interface.
+- Clarified that the default Micro-C workflow does not require restriction enzyme information.
+
+### Notes
+- Restriction-fragment-aware Hi-C behavior, restriction fragment generation, and `pairtools restrict` are not implemented in v0.4.0.
+- Multi-sample execution, restartable chunk processing, workflow-manager files, containers, CI, and full QC reports remain future work.
+
 ## v0.3.0 - Unreleased
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,70 +1,135 @@
 # microC-pipeline
 
-`microC-pipeline` currently contains a legacy/minimal Slurm-based Micro-C preprocessing workflow. The repository is being prepared for future development toward a production-facing pipeline, but the modern engine is planned only and is not implemented yet.
+`microC-pipeline` is a Micro-C preprocessing repository. The v0.4.0 development milestone adds a lightweight config-driven single-sample entrypoint while retaining the historical `mdp.sh` Slurm script for backward compatibility.
 
-The retained runnable workflow centers on one shell script, `mdp.sh`, plus a lightweight Pairtools-stats summarizer, `get_qc.py`. Users should not expect restartable chunk-based execution, sample-sheet orchestration, containers, or a packaged workflow-manager pipeline from the current code.
+The preferred v0.4.0 interface is:
+
+```bash
+bin/microc-pipeline run --config config/example.single-sample.yaml
+```
+
+The retained legacy interface remains:
+
+```bash
+sbatch --time=24:00:00 --cpus-per-task=16 --mem=64g \
+  mdp.sh SAMPLE mm10 /path/to/mm10.fa
+```
+
+This repository is still **not** a modern restartable workflow-manager pipeline. It does not implement restartable chunk-based execution, multi-sample sample sheets, Snakemake or Nextflow workflows, containers, CI, full HTML QC reports, or downstream biological interpretation.
 
 ## What this repository does
 
-For a single sample, `mdp.sh` runs a classic Micro-C preprocessing path:
+For one Micro-C sample, the config-driven runner follows the same core preprocessing path as the retained legacy script:
 
 1. FASTQ quality checks with FastQC.
 2. Adapter/quality trimming with Trim Galore.
-3. Alignment with BWA-MEM.
-4. Pair parsing, sorting, deduplication, and stats with Pairtools.
-5. BAM sorting/indexing with Samtools.
+3. Alignment with BWA-MEM using `bwa mem -5SP -T0`.
+4. Pair parsing and sorting with Pairtools.
+5. Undeduplicated BAM split, sorting, and indexing.
 6. Library complexity estimation with Preseq.
-7. `.hic` generation with Juicer tools.
-8. `.pairs.gz`, `.cool`, and `.mcool` generation with Pairix and Cooler.
-9. A small text QC summary from Pairtools stats using `get_qc.py`.
+7. Pairtools deduplication and stats.
+8. A small QC text summary from `get_qc.py`.
+9. Final deduplicated pairs and BAM generation.
+10. Optional `.hic` generation with Juicer tools.
+11. `.pairs.gz`, Pairix index, `.cool`, and optional `.mcool` generation.
 
-This is **not** a modern, restartable workflow manager pipeline. It does not include restartable chunk-based execution, sample-sheet orchestration, containers, continuous integration, full QC reports, or a packaged software environment.
+The default workflow is Micro-C-oriented. No restriction enzyme is required, the v0.4.0 config does not include an enzyme field, and restriction-fragment-aware Hi-C processing is not implemented in this milestone.
 
 ## Repository contents
 
 ```text
-README.md           Project overview and usage notes
-mdp.sh              Legacy/minimal Slurm Micro-C preprocessing script
-get_qc.py           Small Pairtools-stats QC text summarizer
-CHANGELOG.md        Repository-level change history
-LICENSE             MIT license
-docs/roadmap.md     Development roadmap toward a production-grade pipeline
-docs/design.md      Planning notes for future pipeline design
-docs/outputs.md     Current and planned output documentation notes
-config/README.md    Placeholder for future configuration examples
-examples/README.md  Placeholder for future tiny synthetic examples
-.gitignore          Ignore rules for large genomics outputs and local files
+README.md                         Project overview and usage notes
+bin/microc-pipeline               v0.4.0 config-driven single-sample CLI
+microc_pipeline/                  Python package for config validation and command execution
+config/example.single-sample.yaml Example single-sample Micro-C config
+config/README.md                  Configuration directory notes
+docs/configuration.md             v0.4.0 config reference
+docs/design.md                    Design notes and current boundaries
+docs/outputs.md                   Current config-driven and legacy output notes
+docs/roadmap.md                   Development roadmap
+mdp.sh                            Retained legacy/minimal Slurm Micro-C preprocessing script
+get_qc.py                         Small Pairtools-stats QC text summarizer
+CHANGELOG.md                      Repository-level change history
+LICENSE                           MIT license
+examples/README.md                Placeholder for future tiny synthetic examples
+.gitignore                        Ignore rules for large genomics outputs and local files
 ```
 
-## Expected input and output layout
+## Config-driven v0.4.0 usage
 
-Run the script from the repository root. It expects paired FASTQs in `fastq/` using the historical naming convention:
+Start from `config/example.single-sample.yaml`:
+
+```yaml
+sample: SAMPLE_ID
+
+assay: microc
+
+fastq:
+  r1: fastq/SAMPLE_R1.fastq.gz
+  r2: fastq/SAMPLE_R2.fastq.gz
+
+genome:
+  name: mm10
+  fasta: /path/to/mm10.fa
+  chrom_sizes: null
+
+threads: 16
+
+bin_sizes:
+  - 1000
+
+output_dir: results
+
+outputs:
+  keep_bam: true
+  make_hic: true
+  make_mcool: true
+```
+
+Validate a config:
+
+```bash
+bin/microc-pipeline validate-config --config config/example.single-sample.yaml
+```
+
+Print planned commands without running external tools:
+
+```bash
+bin/microc-pipeline run --config config/example.single-sample.yaml --dry-run
+```
+
+Run one sample:
+
+```bash
+bin/microc-pipeline run --config config/example.single-sample.yaml
+```
+
+The runner requires explicit FASTQ paths in the config rather than the legacy hard-coded `fastq/{SAMPLE_ID}_R1_001.fastq.gz` and `fastq/{SAMPLE_ID}_R2_001.fastq.gz` names. See `docs/configuration.md` for required fields, defaults, dry-run behavior, genome FASTA index handling, and current limitations.
+
+## Config-driven output layout
+
+The v0.4.0 runner writes under a per-sample directory:
 
 ```text
-fastq/{SAMPLE_ID}_R1_001.fastq.gz
-fastq/{SAMPLE_ID}_R2_001.fastq.gz
+results/SAMPLE/
+  bam/
+  cool/
+  fastqc/
+  hic/
+  genome/
+  logs/
+  pairs/
+  qc/
+  stats/
+  temp/
+  run_metadata.json
 ```
 
-The script creates and uses these output/work directories:
-
-```text
-BAM/      sorted/indexed BAM outputs
-cool/     .cool and zoomified .mcool outputs
-fastqc/   FastQC reports
-fastq/    input FASTQs and Trim Galore outputs
-hic/      .hic outputs
-genome/   generated chromosome sizes files
-pairs/    .pairs.gz and pairix index outputs
-stats/    pairtools, preseq, and QC summary text outputs
-temp/     intermediate SAM/pairsam files
-logs/     per-sample pipeline logs
-```
-
-Large genomics outputs and inputs are ignored by Git so the public repository stays small and safe.
+For real runs, `run_metadata.json` records the resolved sample, assay, config path, output directory, genome resources, FASTQ paths, threads, bin sizes, output toggles, pipeline version, dry-run status, timestamp, and command list. The metadata does not include restriction enzyme information.
 
 ## Requirements
 
-Install and configure dependencies before submitting a job. The script checks for these commands and exits early if any are missing:
+Install and configure dependencies before launching a real run. The config-driven runner checks for required commands and exits early if any are missing:
 
 - `fastqc`
 - `trim_galore`
@@ -72,19 +137,31 @@ Install and configure dependencies before submitting a job. The script checks fo
 - `bwa`
 - `pairtools`
 - `preseq`
-- `juicer_tools`
 - `bgzip`
 - `pairix`
 - `cooler`
 - `python3`
 
-The required genome FASTA should already have any aligner indexes needed by BWA. `GENOME_FASTA` should also have an existing non-empty `.fai` index, or the directory containing `GENOME_FASTA` must be writable so `mdp.sh` can create the index with `samtools faidx`. The script derives `genome/{GENOME_NAME}.chrom.sizes` from that FASTA index for Pairtools and Cooler.
+The runner checks `juicer_tools` only when `outputs.make_hic: true`.
+
+The required genome FASTA should already have BWA indexes available for alignment. If `genome.chrom_sizes` is not provided, `genome.fasta` should have an existing non-empty `.fai` index, or the FASTA directory must be writable so the runner can create the index with `samtools faidx`.
 
 ### HPC modules are site-specific
 
-Many HPC clusters expose tools through environment modules, but module names vary by site. `mdp.sh` includes a clearly marked optional module-loading section that you may edit for your cluster. The script does not install software during a run; if a command such as `cooler` is unavailable, it fails during dependency checks.
+Many HPC clusters expose tools through environment modules, but module names vary by site. Neither the config-driven runner nor `mdp.sh` installs software during a run; missing commands are reported as dependency errors.
 
-## Usage
+## Retained legacy `mdp.sh` usage
+
+`mdp.sh` remains available as the retained legacy/minimal direct Slurm script. It uses historical root-level output directories and historical FASTQ naming assumptions.
+
+Run the script from the repository root. It expects paired FASTQs in `fastq/` using this naming convention:
+
+```text
+fastq/{SAMPLE_ID}_R1_001.fastq.gz
+fastq/{SAMPLE_ID}_R2_001.fastq.gz
+```
+
+Submit a legacy Slurm job:
 
 ```bash
 sbatch --time=24:00:00 --cpus-per-task=16 --mem=64g \
@@ -104,41 +181,28 @@ Arguments:
 - `GENOME_NAME`: short genome label used for generated files and Juicer tools, for example `mm10` or `hg38`.
 - `GENOME_FASTA`: path to the reference FASTA.
 
-Threading defaults to `SLURM_CPUS_PER_TASK` when set, otherwise `16`:
+Threading defaults to `SLURM_CPUS_PER_TASK` when set, otherwise `16`.
 
-```bash
-THREADS="${SLURM_CPUS_PER_TASK:-16}"
-```
+The legacy script creates and uses root-level directories such as `BAM/`, `cool/`, `fastqc/`, `hic/`, `genome/`, `pairs/`, `stats/`, `temp/`, and `logs/`.
 
 ## QC summary
 
-After Pairtools deduplication, `mdp.sh` writes Pairtools stats to:
-
-```text
-stats/{SAMPLE_ID}.txt
-```
-
-It then creates a compact text summary with:
+After Pairtools deduplication, both workflows can create a compact text summary from Pairtools stats with `get_qc.py`:
 
 ```bash
 python3 get_qc.py -p stats/SAMPLE.txt > stats/qc_SAMPLE.txt
 ```
 
-You can rerun that command manually after a completed or partially completed run if `stats/SAMPLE.txt` exists.
+The config-driven runner writes its QC summary under `results/SAMPLE/qc/`.
 
 ## Notes and limitations
 
-- This is a legacy/minimal Slurm script, not a fully restartable production workflow.
-- The repository is being prepared for future development, but the future production-facing pipeline is not implemented yet.
-- Restartable chunk-based execution is not available in the current code.
-- Paths and FASTQ naming are intentionally simple and historical.
-- Intermediate files may be removed after downstream files are created, matching the previous script behavior.
-- Module names and dependency installation are intentionally left to each HPC site.
-- Full biological validation requires running on real data and inspecting the outputs; syntax checks alone do not validate biological correctness.
-- Licensed under MIT. See `LICENSE`.
+- v0.4.0 supports only one sample per config/run command.
+- Multi-sample support is not implemented yet.
+- Restartable chunk-based processing is not implemented yet.
+- The repository does not include workflow-manager files, containers, CI, full QC reports, or project-level QC summaries.
+- The default workflow is Micro-C-oriented and does not require restriction enzyme information.
+- Enzyme-aware Hi-C processing, restriction fragment generation, and `pairtools restrict` are not implemented.
+- Downstream loop calling, compartment calling, TAD calling, differential contact analysis, and biological interpretation are outside the current scope.
 
-## Version note
-
-Legacy script version history is retained in comments at the bottom of `mdp.sh`. Repository-level release history is tracked in `CHANGELOG.md`.
-
-The `v0.2.0` milestone was an internal, untagged repository-polish milestone for the legacy/minimal Slurm workflow. The next public-facing milestone is `v0.3.0`, focused on project structure and identity. It does not make this repository a fully restartable workflow manager pipeline.
+Large genomics outputs and inputs are ignored by Git so the public repository stays small and safe.

--- a/bin/microc-pipeline
+++ b/bin/microc-pipeline
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+"""Command-line entrypoint for the lightweight microC-pipeline runner."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from microc_pipeline.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/config/README.md
+++ b/config/README.md
@@ -1,7 +1,19 @@
 # Configuration directory
 
-This directory is reserved for future configuration examples and schemas.
+This directory contains example configuration files for the lightweight config-driven single-sample Micro-C runner.
 
-No modern config-driven runner is implemented yet. The current runnable workflow is still `mdp.sh`, which accepts command-line arguments and uses the legacy FASTQ layout described in `README.md`.
+- `example.single-sample.yaml` documents the v0.4.0 single-sample config format.
 
-Future configuration work may define sample metadata, FASTQ paths, genome resources, output options, threading, and QC settings.
+Validate a config before launching a full run:
+
+```bash
+bin/microc-pipeline validate-config --config config/example.single-sample.yaml
+```
+
+Print the planned command sequence without running external tools:
+
+```bash
+bin/microc-pipeline run --config config/example.single-sample.yaml --dry-run
+```
+
+The default v0.4.0 workflow is Micro-C-oriented and does not require restriction enzyme information.

--- a/config/example.single-sample.yaml
+++ b/config/example.single-sample.yaml
@@ -1,0 +1,24 @@
+sample: SAMPLE_ID
+
+assay: microc
+
+fastq:
+  r1: fastq/SAMPLE_R1.fastq.gz
+  r2: fastq/SAMPLE_R2.fastq.gz
+
+genome:
+  name: mm10
+  fasta: /path/to/mm10.fa
+  chrom_sizes: null
+
+threads: 16
+
+bin_sizes:
+  - 1000
+
+output_dir: results
+
+outputs:
+  keep_bam: true
+  make_hic: true
+  make_mcool: true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,133 @@
+# Configuration guide
+
+The v0.4.0 workflow adds a small config-driven interface for one Micro-C sample:
+
+```bash
+bin/microc-pipeline run --config config/example.single-sample.yaml
+```
+
+Use `validate-config` before running a full preprocessing job:
+
+```bash
+bin/microc-pipeline validate-config --config config/example.single-sample.yaml
+```
+
+Use dry-run mode to print the planned command sequence without running external tools or creating large outputs:
+
+```bash
+bin/microc-pipeline run --config config/example.single-sample.yaml --dry-run
+```
+
+The v0.4.0 workflow is Micro-C-oriented and does not require restriction enzyme information. Restriction-fragment-aware Hi-C behavior may be considered in a future milestone, but it is not implemented now.
+
+## Example config
+
+```yaml
+sample: SAMPLE_ID
+
+assay: microc
+
+fastq:
+  r1: fastq/SAMPLE_R1.fastq.gz
+  r2: fastq/SAMPLE_R2.fastq.gz
+
+genome:
+  name: mm10
+  fasta: /path/to/mm10.fa
+  chrom_sizes: null
+
+threads: 16
+
+bin_sizes:
+  - 1000
+
+output_dir: results
+
+outputs:
+  keep_bam: true
+  make_hic: true
+  make_mcool: true
+```
+
+Path values are interpreted by the command shell from the directory where you run `bin/microc-pipeline`. Absolute paths are recommended for shared genome resources.
+
+## Required fields
+
+| Field | Meaning |
+| --- | --- |
+| `sample` | Single sample identifier used for the per-sample output directory and output filenames. |
+| `fastq.r1` | Explicit path to read 1 FASTQ. |
+| `fastq.r2` | Explicit path to read 2 FASTQ. |
+| `genome.name` | Short genome label, for example `mm10` or `hg38`. |
+| `genome.fasta` | Path to the reference FASTA. BWA indexes must already be available for alignment. |
+| `output_dir` | Root output directory. The workflow writes to `output_dir/sample`. |
+
+## Optional fields and defaults
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `assay` | `microc` | v0.4.0 supports only `microc`. Unsupported values fail clearly. |
+| `genome.chrom_sizes` | `null` | Optional chromosome sizes file. If absent or null, the runner derives chromosome sizes from `${genome.fasta}.fai`. |
+| `threads` | `SLURM_CPUS_PER_TASK`, otherwise `16` | Thread count passed to supported tools. |
+| `bin_sizes` | `[1000]` | Configured contact matrix bin sizes. v0.4.0 uses only the first value for `.cool` generation and warns when more are provided. |
+| `outputs.keep_bam` | `true` | Keep or remove the final `bam/SAMPLE.PT.bam` and index after downstream outputs are created. |
+| `outputs.make_hic` | `true` | Run `juicer_tools pre` to create `hic/SAMPLE.hic`. |
+| `outputs.make_mcool` | `true` | Run `cooler zoomify` to create a multiresolution Cooler output. |
+
+## Assay behavior
+
+If `assay` is omitted, the runner treats the sample as Micro-C:
+
+```yaml
+assay: microc
+```
+
+No `hic` assay mode is implemented in v0.4.0. For example, `assay: hic` fails with:
+
+```text
+Unsupported assay: hic. v0.4.0 supports only assay: microc.
+```
+
+## Genome FASTA index and chromosome sizes
+
+The runner uses `genome.fasta` as the reference FASTA. If `genome.chrom_sizes` is provided, that file is copied into the sample output directory. If `genome.chrom_sizes` is absent or null, the runner requires a non-empty `${genome.fasta}.fai`, or creates one with `samtools faidx` when the FASTA directory is writable.
+
+For real runs, the workflow writes the chromosome sizes file to:
+
+```text
+results/SAMPLE/genome/{genome.name}.chrom.sizes
+```
+
+That file is used by Pairtools and Cooler.
+
+## Output directory behavior
+
+The config-driven workflow writes under a per-sample directory:
+
+```text
+results/SAMPLE/
+  bam/
+  cool/
+  fastqc/
+  hic/
+  genome/
+  logs/
+  pairs/
+  qc/
+  stats/
+  temp/
+  run_metadata.json
+```
+
+If `output_dir: .` is set explicitly, the per-sample directory is created in the current directory as `./SAMPLE/`. The retained legacy `mdp.sh` script continues to use its historical repository-root output directories.
+
+## Current limitations
+
+- v0.4.0 supports one sample per command.
+- Multi-sample sample sheets are not implemented.
+- Restartable chunk-based execution is not implemented.
+- Snakemake and Nextflow workflow-manager implementations are not included.
+- Containers and CI are not included.
+- Full HTML QC reports and project-level QC summaries are not included.
+- Restriction-fragment-aware Hi-C behavior, restriction fragment generation, and `pairtools restrict` are not implemented.
+- Loop calling, compartment calling, TAD calling, differential contact analysis, and biological interpretation are outside the preprocessing scope.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,17 +1,26 @@
 # Design notes
 
-This document records current design assumptions for `microC-pipeline` as the repository is prepared for the `v0.3.0` project-structure milestone.
+This document records current design assumptions for `microC-pipeline` as the repository moves through the v0.4.0 config-driven single-sample milestone.
 
 ## Current implementation status
 
-- `mdp.sh` remains the retained legacy/minimal Slurm script.
-- The current runnable workflow is single-sample oriented and uses historical FASTQ naming assumptions.
-- The modern production-facing pipeline engine is not implemented yet.
+- `bin/microc-pipeline` provides a lightweight config-driven single-sample Micro-C entrypoint.
+- `mdp.sh` remains the retained legacy/minimal Slurm script for backward compatibility.
+- The config-driven runner removes the legacy need to edit hard-coded FASTQ names by accepting explicit `fastq.r1` and `fastq.r2` paths in YAML.
+- The current runnable workflows remain single-sample oriented.
 - Restartable chunk-based execution is not available in the current repository.
+- Multi-sample sample-sheet orchestration is not implemented.
+- Snakemake and Nextflow engines are not implemented.
+
+## v0.4.0 design boundary
+
+The v0.4.0 implementation is intentionally small. It validates one YAML config, creates one per-sample output directory, derives or copies chromosome sizes, writes structured metadata, and executes the same core Micro-C preprocessing path as the legacy script.
+
+The default workflow is Micro-C-oriented and does not require restriction enzyme information. Restriction-fragment-aware Hi-C behavior may be considered in a future milestone, but v0.4.0 does not implement restriction fragment generation, `pairtools restrict`, or enzyme-aware processing.
 
 ## Engine direction planning note
 
-No final engine choice has been made for the future production-facing workflow.
+No final engine choice has been made for a future production-facing workflow.
 
 Candidate future directions include:
 
@@ -23,4 +32,4 @@ HiC-Nap restartable chunk-processing concepts are expected to inform future deve
 
 ## Near-term design boundaries
 
-The `v0.3.0` milestone is limited to project identity and lightweight structure. It should not add the modern engine, sample-sheet execution, workflow-manager files, containers, CI, or full QC reports.
+Near-term work should avoid turning v0.4.0 into a large framework. Later milestones may standardize valid pairs and matrix outputs, add restartable chunk execution, choose a workflow engine, add sample-sheet support, improve QC, and introduce packaging or containers.

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -1,10 +1,47 @@
 # Output notes
 
-This document describes current legacy outputs and planned future output organization. It is a planning document, not a guarantee that the modern output layout has been implemented.
+This document distinguishes the current v0.4.0 config-driven output layout from retained legacy `mdp.sh` outputs and future planned outputs.
 
-## Current legacy outputs
+## Current config-driven outputs
 
-The retained `mdp.sh` workflow writes outputs and intermediates into repository-root directories such as:
+The preferred v0.4.0 single-sample runner writes outputs under `output_dir/sample`. With the example `output_dir: results` and `sample: SAMPLE`, the layout is:
+
+```text
+results/SAMPLE/
+  bam/
+  cool/
+  fastqc/
+  hic/
+  genome/
+  logs/
+  pairs/
+  qc/
+  stats/
+  temp/
+  run_metadata.json
+```
+
+Directory roles:
+
+- `bam/`: undeduplicated and final sorted/indexed BAM files. If `outputs.keep_bam: false`, the final `SAMPLE.PT.bam` and `.bai` are removed after downstream files are created.
+- `cool/`: first-bin `.cool` output and optional zoomified `.mcool` output.
+- `fastqc/`: FastQC outputs.
+- `hic/`: optional `SAMPLE.hic` when `outputs.make_hic: true`.
+- `genome/`: copied or derived `{genome.name}.chrom.sizes` file used by Pairtools and Cooler.
+- `logs/`: per-sample log file with resolved settings and command lines.
+- `pairs/`: deduplicated pairs, BGZF-compressed pairs, and Pairix index.
+- `qc/`: compact QC text summary produced by `get_qc.py`.
+- `stats/`: Pairtools stats and Preseq complexity output.
+- `temp/`: intermediate SAM, pairsam, and trimmed FASTQ files.
+- `run_metadata.json`: structured run metadata for real runs.
+
+The v0.4.0 runner always creates `.cool` for the first configured bin size. If multiple `bin_sizes` are configured, it warns that only the first value is used. It creates `.hic` only when `outputs.make_hic: true` and runs `cooler zoomify` only when `outputs.make_mcool: true`.
+
+`run_metadata.json` includes sample, assay, config path, output directory, genome FASTA, chromosome sizes path, FASTQ paths, thread count, bin sizes, output toggles, pipeline version, dry-run status, timestamp, and command records. It does not include restriction enzyme information.
+
+## Retained legacy `mdp.sh` outputs
+
+The retained legacy/minimal Slurm script writes outputs and intermediates into repository-root directories such as:
 
 ```text
 BAM/
@@ -18,17 +55,21 @@ temp/
 logs/
 ```
 
-These paths reflect the legacy/minimal Slurm workflow and may include intermediates that are removed after downstream products are created.
+These paths reflect the historical direct script workflow. They are kept for backward compatibility and are separate from the v0.4.0 per-sample `results/SAMPLE/` layout.
 
-## Planned future output direction
+## Future planned outputs
 
-A future production-facing pipeline should make final, temporary, and diagnostic outputs explicit. A candidate future layout is documented in `docs/roadmap.md`, but it is not implemented yet.
+Later milestones may standardize final valid pairs and matrix products as first-class outputs, validate output files, and add richer QC files. A candidate future layout remains:
 
-Expected future documentation should define:
+```text
+results/SAMPLE/
+  pairs/SAMPLE.valid.pairs.gz
+  pairs/SAMPLE.valid.pairs.gz.px2
+  cool/SAMPLE.cool
+  cool/SAMPLE.mcool
+  hic/SAMPLE.hic
+  stats/SAMPLE.pairtools.stats.txt
+  qc/SAMPLE.qc.tsv
+```
 
-- final contact-pair outputs and indexes
-- contact matrix outputs
-- optional BAM retention
-- run metadata
-- QC tables, JSON, and reports
-- temporary files and cleanup behavior
+Optional future outputs may include retained final BAM files under `results/SAMPLE/bam/`. Restartable chunk outputs, project-level QC summaries, and full reports remain future work.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,9 +55,9 @@ The v1.0.0 release should be built around the following principles.
    - The pipeline should not only produce contact files, but also help decide whether a library is usable.
    - QC should summarize mapping, duplication, valid pairs, cis/trans balance, distance decay, and matrix-level properties.
 
-6. **Micro-C / Hi-C compatibility**
-   - The workflow should support Micro-C and Hi-C-like paired-end proximity ligation data.
-   - Enzyme/restriction-fragment assumptions should be explicit and configurable.
+6. **Micro-C first, with future Hi-C compatibility considered carefully**
+   - The current workflow should remain Micro-C-oriented by default.
+   - Any future Hi-C-specific assumptions should be documented explicitly and added only in a later milestone.
 
 ## Relationship to HiC-Nap
 
@@ -136,43 +136,59 @@ The project has a clear identity: legacy script retained, modern pipeline planne
 
 ## Milestone v0.4.0: config-driven single-sample workflow
 
-Goal: remove hard-coded sample naming and path assumptions.
+Goal: remove hard-coded sample naming and path assumptions for one Micro-C sample.
 
-Planned tasks:
+Completed tasks:
 
-- Add a config file format, for example `config.yaml`.
-- Add support for explicit FASTQ paths.
-- Add configurable genome name, FASTA, chrom sizes, enzyme, bin sizes, and output directory.
-- Add a dry-run or command-printing mode.
-- Add structured run metadata output.
-- Keep a single-sample mode as the simplest supported workflow.
+- [x] Add the `bin/microc-pipeline` executable entrypoint.
+- [x] Add a single-sample YAML config format.
+- [x] Add `config/example.single-sample.yaml` without restriction enzyme settings.
+- [x] Add support for explicit `fastq.r1` and `fastq.r2` paths.
+- [x] Add configurable genome name, FASTA, optional chromosome sizes, bin sizes, threads, output directory, and output toggles.
+- [x] Default `assay` to `microc` and reject unsupported assay values.
+- [x] Add config validation with clear missing-field, type, assay, and missing-file errors.
+- [x] Add dry-run command printing.
+- [x] Add per-sample output directory handling under `output_dir/sample`.
+- [x] Add structured run metadata for real runs.
+- [x] Keep the retained legacy `mdp.sh` script available and documented.
 
-Example future config:
+Explicit non-goals for v0.4.0:
+
+- [ ] Multi-sample sample-sheet execution.
+- [ ] Restartable chunk-based execution.
+- [ ] Snakemake or Nextflow workflow-manager implementation.
+- [ ] Containers or CI.
+- [ ] Full HTML QC reports or project-level QC summaries.
+- [ ] Restriction-fragment-aware Hi-C behavior, restriction fragment generation, or `pairtools restrict`.
+
+Example current config:
 
 ```yaml
 sample: SAMPLE_ID
-fastq1: fastq/SAMPLE_R1.fastq.gz
-fastq2: fastq/SAMPLE_R2.fastq.gz
-genome_name: mm10
-genome_fasta: /path/to/mm10.fa
-enzyme: MboI
+assay: microc
+fastq:
+  r1: fastq/SAMPLE_R1.fastq.gz
+  r2: fastq/SAMPLE_R2.fastq.gz
+genome:
+  name: mm10
+  fasta: /path/to/mm10.fa
+  chrom_sizes: null
 threads: 16
 bin_sizes:
   - 1000
-  - 5000
-  - 10000
-  - 25000
-  - 100000
+output_dir: results
 outputs:
-  keep_bam: false
+  keep_bam: true
   make_hic: true
   make_mcool: true
 ```
 
+The v0.4.0 workflow is Micro-C-oriented and does not require restriction enzyme information. Restriction-fragment-aware Hi-C behavior may be considered in a future milestone, but it is not implemented now.
+
 Expected status after this milestone:
 
 ```text
-Users can run a single sample without editing the script itself.
+Users can run a single Micro-C sample without editing the legacy script itself.
 ```
 
 ## Milestone v0.5.0: valid pairs and matrix outputs as first-class products
@@ -226,7 +242,7 @@ Planned tasks:
   - alignment
   - pairtools parse
   - pairtools sort
-  - pairtools restrict/select when appropriate
+  - pairtools parse/sort-compatible selection steps when appropriate
 - Add per-chunk status files.
 - Add conservative restart behavior.
 - Add global merge and global deduplication.
@@ -287,7 +303,7 @@ Goal: support project-scale processing.
 Planned tasks:
 
 - Add sample sheet support.
-- Allow per-sample FASTQ, genome, enzyme, and condition metadata.
+- Allow per-sample FASTQ, genome, assay, and condition metadata.
 - Process failed samples independently on rerun.
 - Generate project-level QC summary.
 - Add optional grouping by condition or batch.
@@ -295,10 +311,10 @@ Planned tasks:
 Example sample sheet:
 
 ```csv
-sample,fastq1,fastq2,genome,enzyme,condition
-WT_rep1,fastq/WT1_R1.fastq.gz,fastq/WT1_R2.fastq.gz,mm10,MboI,WT
-WT_rep2,fastq/WT2_R1.fastq.gz,fastq/WT2_R2.fastq.gz,mm10,MboI,WT
-DS_rep1,fastq/DS1_R1.fastq.gz,fastq/DS1_R2.fastq.gz,mm10,MboI,DS
+sample,fastq1,fastq2,genome,assay,condition
+WT_rep1,fastq/WT1_R1.fastq.gz,fastq/WT1_R2.fastq.gz,mm10,microc,WT
+WT_rep2,fastq/WT2_R1.fastq.gz,fastq/WT2_R2.fastq.gz,mm10,microc,WT
+DS_rep1,fastq/DS1_R1.fastq.gz,fastq/DS1_R2.fastq.gz,mm10,microc,DS
 ```
 
 Expected status after this milestone:

--- a/microc_pipeline/__init__.py
+++ b/microc_pipeline/__init__.py
@@ -1,0 +1,3 @@
+"""Lightweight config-driven Micro-C preprocessing entrypoint."""
+
+__version__ = "v0.4.0-dev"

--- a/microc_pipeline/cli.py
+++ b/microc_pipeline/cli.py
@@ -1,0 +1,58 @@
+"""CLI for the v0.4.0 config-driven single-sample Micro-C runner."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .config import ConfigError, parse_and_validate_config
+from .runner import RunnerError, run_pipeline, validate_chrom_sizes_feasibility
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="microc-pipeline",
+        description="Lightweight config-driven single-sample Micro-C preprocessing runner.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="Run the single-sample Micro-C workflow.")
+    run_parser.add_argument("--config", required=True, help="YAML config file for one sample.")
+    run_parser.add_argument("--dry-run", action="store_true", help="Print planned commands without running tools.")
+
+    validate_parser = subparsers.add_parser("validate-config", help="Validate a single-sample YAML config.")
+    validate_parser.add_argument("--config", required=True, help="YAML config file to validate.")
+    return parser
+
+
+def command_validate_config(args: argparse.Namespace) -> int:
+    config = parse_and_validate_config(args.config, check_files=True)
+    validate_chrom_sizes_feasibility(config)
+    print(f"Config validation succeeded for sample: {config.sample}")
+    print(f"Assay: {config.assay}")
+    print(f"Output directory: {config.sample_output_dir}")
+    return 0
+
+
+def command_run(args: argparse.Namespace) -> int:
+    config = parse_and_validate_config(args.config, check_files=True)
+    validate_chrom_sizes_feasibility(config)
+    run_pipeline(config, dry_run=args.dry_run)
+    if not args.dry_run:
+        print(f"Run completed for sample: {config.sample}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "validate-config":
+            return command_validate_config(args)
+        if args.command == "run":
+            return command_run(args)
+        parser.error(f"Unknown command: {args.command}")
+    except (ConfigError, RunnerError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    return 0

--- a/microc_pipeline/config.py
+++ b/microc_pipeline/config.py
@@ -1,0 +1,265 @@
+"""Configuration loading and validation for the v0.4.0 single-sample runner."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class ConfigError(ValueError):
+    """Raised when a configuration file is invalid."""
+
+
+@dataclass(frozen=True)
+class GenomeConfig:
+    name: str
+    fasta: Path
+    chrom_sizes: Path | None
+
+
+@dataclass(frozen=True)
+class OutputConfig:
+    keep_bam: bool = True
+    make_hic: bool = True
+    make_mcool: bool = True
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    sample: str
+    assay: str
+    fastq_r1: Path
+    fastq_r2: Path
+    genome: GenomeConfig
+    threads: int
+    bin_sizes: list[int]
+    output_root: Path
+    sample_output_dir: Path
+    outputs: OutputConfig
+    config_path: Path
+    raw: dict[str, Any]
+
+
+_MISSING = object()
+
+
+def _strip_comment(line: str) -> str:
+    in_single = False
+    in_double = False
+    escaped = False
+    result = []
+    for char in line:
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single and not escaped:
+            in_double = not in_double
+        elif char == "#" and not in_single and not in_double:
+            break
+        result.append(char)
+        escaped = char == "\\" and not escaped
+    return "".join(result).rstrip()
+
+
+def _parse_scalar(value: str) -> Any:
+    value = value.strip()
+    if value in {"", "null", "Null", "NULL", "~"}:
+        return None
+    if value in {"true", "True", "TRUE"}:
+        return True
+    if value in {"false", "False", "FALSE"}:
+        return False
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    try:
+        return int(value)
+    except ValueError:
+        return value
+
+
+def _parse_simple_yaml(text: str) -> dict[str, Any]:
+    """Parse the small YAML subset used by the documented v0.4.0 config.
+
+    This intentionally supports mappings, nested mappings, scalar values, and
+    lists of scalar values so the runner does not need an external Python YAML
+    dependency on minimal HPC login nodes. It is not a general YAML parser.
+    """
+
+    root: dict[str, Any] = {}
+    stack: list[tuple[int, Any]] = [(-1, root)]
+    lines = text.splitlines()
+
+    for line_number, original_line in enumerate(lines, start=1):
+        line = _strip_comment(original_line)
+        if not line.strip():
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        if indent % 2 != 0:
+            raise ConfigError(f"Invalid indentation at line {line_number}: use multiples of two spaces.")
+        stripped = line.strip()
+
+        while stack and indent <= stack[-1][0]:
+            stack.pop()
+        if not stack:
+            raise ConfigError(f"Invalid indentation at line {line_number}.")
+        parent = stack[-1][1]
+
+        if stripped.startswith("- "):
+            if not isinstance(parent, list):
+                raise ConfigError(f"Unexpected list item at line {line_number}.")
+            parent.append(_parse_scalar(stripped[2:]))
+            continue
+
+        if ":" not in stripped:
+            raise ConfigError(f"Expected key/value pair at line {line_number}.")
+        key, value = stripped.split(":", 1)
+        key = key.strip()
+        if not key:
+            raise ConfigError(f"Empty key at line {line_number}.")
+        if not isinstance(parent, dict):
+            raise ConfigError(f"Cannot add key under list at line {line_number}.")
+
+        value = value.strip()
+        if value == "":
+            next_container: Any = {}
+            for following in lines[line_number:]:
+                following_clean = _strip_comment(following)
+                if not following_clean.strip():
+                    continue
+                following_indent = len(following_clean) - len(following_clean.lstrip(" "))
+                following_stripped = following_clean.strip()
+                if following_indent <= indent:
+                    break
+                if following_stripped.startswith("- "):
+                    next_container = []
+                break
+            parent[key] = next_container
+            stack.append((indent, next_container))
+        else:
+            parent[key] = _parse_scalar(value)
+
+    return root
+
+
+def load_config_file(path: str | os.PathLike[str]) -> dict[str, Any]:
+    config_path = Path(path)
+    if not config_path.exists():
+        raise ConfigError(f"Config file not found: {config_path}")
+    try:
+        return _parse_simple_yaml(config_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ConfigError(f"Could not read config file: {config_path}: {exc}") from exc
+
+
+def _get_required(mapping: dict[str, Any], dotted: str) -> Any:
+    current: Any = mapping
+    for part in dotted.split("."):
+        if not isinstance(current, dict) or part not in current or current[part] in (None, ""):
+            raise ConfigError(f"Missing required config field: {dotted}")
+        current = current[part]
+    return current
+
+
+def _get_optional(mapping: dict[str, Any], dotted: str, default: Any = None) -> Any:
+    current: Any = mapping
+    for part in dotted.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return default
+        current = current[part]
+    return current
+
+
+def _require_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"Invalid config field {field}: expected a non-empty string.")
+    return value
+
+
+def _require_bool(value: Any, field: str) -> bool:
+    if not isinstance(value, bool):
+        raise ConfigError(f"Invalid config field {field}: expected true or false.")
+    return value
+
+
+def _resolve_path(value: Any, field: str) -> Path:
+    return Path(_require_string(value, field)).expanduser()
+
+
+def _validate_existing_file(path: Path, field: str) -> None:
+    if not path.is_file():
+        raise ConfigError(f"{field} not found: {path}")
+
+
+def parse_and_validate_config(
+    config_path: str | os.PathLike[str], *, check_files: bool = True
+) -> PipelineConfig:
+    raw = load_config_file(config_path)
+    if not isinstance(raw, dict):
+        raise ConfigError("Config root must be a mapping.")
+
+    sample = _require_string(_get_required(raw, "sample"), "sample")
+    assay = _require_string(_get_optional(raw, "assay", "microc"), "assay")
+    if assay != "microc":
+        raise ConfigError(f"Unsupported assay: {assay}. v0.4.0 supports only assay: microc.")
+
+    fastq_r1 = _resolve_path(_get_required(raw, "fastq.r1"), "fastq.r1")
+    fastq_r2 = _resolve_path(_get_required(raw, "fastq.r2"), "fastq.r2")
+    genome_name = _require_string(_get_required(raw, "genome.name"), "genome.name")
+    genome_fasta = _resolve_path(_get_required(raw, "genome.fasta"), "genome.fasta")
+    chrom_sizes_value = _get_optional(raw, "genome.chrom_sizes", None)
+    chrom_sizes = None if chrom_sizes_value in (None, "") else _resolve_path(chrom_sizes_value, "genome.chrom_sizes")
+    output_root = _resolve_path(_get_required(raw, "output_dir"), "output_dir")
+
+    threads_value = _get_optional(raw, "threads", None)
+    if threads_value is None:
+        threads_value = os.environ.get("SLURM_CPUS_PER_TASK", 16)
+    try:
+        threads = int(threads_value)
+    except (TypeError, ValueError) as exc:
+        raise ConfigError("Invalid config field threads: expected a positive integer.") from exc
+    if threads < 1:
+        raise ConfigError("Invalid config field threads: expected a positive integer.")
+
+    bin_sizes_value = _get_optional(raw, "bin_sizes", [1000])
+    if not isinstance(bin_sizes_value, list) or not bin_sizes_value:
+        raise ConfigError("Invalid config field bin_sizes: expected a non-empty list of positive integers.")
+    bin_sizes: list[int] = []
+    for index, bin_size in enumerate(bin_sizes_value):
+        try:
+            parsed = int(bin_size)
+        except (TypeError, ValueError) as exc:
+            raise ConfigError(f"Invalid config field bin_sizes[{index}]: expected a positive integer.") from exc
+        if parsed < 1:
+            raise ConfigError(f"Invalid config field bin_sizes[{index}]: expected a positive integer.")
+        bin_sizes.append(parsed)
+
+    outputs = OutputConfig(
+        keep_bam=_require_bool(_get_optional(raw, "outputs.keep_bam", True), "outputs.keep_bam"),
+        make_hic=_require_bool(_get_optional(raw, "outputs.make_hic", True), "outputs.make_hic"),
+        make_mcool=_require_bool(_get_optional(raw, "outputs.make_mcool", True), "outputs.make_mcool"),
+    )
+
+    if check_files:
+        _validate_existing_file(fastq_r1, "FASTQ R1")
+        _validate_existing_file(fastq_r2, "FASTQ R2")
+        _validate_existing_file(genome_fasta, "Genome FASTA")
+        if chrom_sizes is not None:
+            _validate_existing_file(chrom_sizes, "Genome chromosome sizes")
+
+    return PipelineConfig(
+        sample=sample,
+        assay=assay,
+        fastq_r1=fastq_r1,
+        fastq_r2=fastq_r2,
+        genome=GenomeConfig(name=genome_name, fasta=genome_fasta, chrom_sizes=chrom_sizes),
+        threads=threads,
+        bin_sizes=bin_sizes,
+        output_root=output_root,
+        sample_output_dir=output_root / sample,
+        outputs=outputs,
+        config_path=Path(config_path),
+        raw=raw,
+    )

--- a/microc_pipeline/runner.py
+++ b/microc_pipeline/runner.py
@@ -1,0 +1,267 @@
+"""Command construction and execution for the v0.4.0 single-sample workflow."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from shlex import quote
+
+from . import __version__
+from .config import ConfigError, PipelineConfig
+
+OUTPUT_SUBDIRS = ("bam", "cool", "fastqc", "hic", "genome", "logs", "pairs", "qc", "stats", "temp")
+REQUIRED_COMMANDS = (
+    "fastqc",
+    "trim_galore",
+    "samtools",
+    "bwa",
+    "pairtools",
+    "preseq",
+    "bgzip",
+    "pairix",
+    "cooler",
+    "python3",
+)
+
+
+class RunnerError(RuntimeError):
+    """Raised when execution cannot continue."""
+
+
+def q(value: object) -> str:
+    return quote(str(value))
+
+
+def trim_galore_output_name(fastq: Path, read_number: int) -> str:
+    name = fastq.name
+    for suffix in (".fastq.gz", ".fq.gz", ".fastq", ".fq"):
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+            break
+    return f"{name}_val_{read_number}.fq.gz"
+
+
+def check_dependencies(config: PipelineConfig) -> None:
+    required = list(REQUIRED_COMMANDS)
+    if config.outputs.make_hic:
+        required.append("juicer_tools")
+    missing = [command for command in required if shutil.which(command) is None]
+    if missing:
+        raise RunnerError("Missing required command(s): " + ", ".join(missing))
+
+
+def ensure_output_dirs(config: PipelineConfig) -> dict[str, Path]:
+    sample_dir = config.sample_output_dir
+    dirs = {name: sample_dir / name for name in OUTPUT_SUBDIRS}
+    sample_dir.mkdir(parents=True, exist_ok=True)
+    for path in dirs.values():
+        path.mkdir(parents=True, exist_ok=True)
+    return dirs
+
+
+def derive_chrom_sizes(config: PipelineConfig, dirs: dict[str, Path], *, dry_run: bool) -> tuple[Path, list[str]]:
+    target = dirs["genome"] / f"{config.genome.name}.chrom.sizes"
+    commands: list[str] = []
+    if config.genome.chrom_sizes is not None:
+        commands.append(f"cp {q(config.genome.chrom_sizes)} {q(target)}")
+        if not dry_run:
+            shutil.copyfile(config.genome.chrom_sizes, target)
+        return target, commands
+
+    fai = Path(str(config.genome.fasta) + ".fai")
+    if not fai.is_file() or fai.stat().st_size == 0:
+        fasta_dir = config.genome.fasta.parent
+        if not dry_run and not fasta_dir.exists():
+            raise RunnerError(f"FASTA directory does not exist: {fasta_dir}")
+        if not dry_run and not fasta_dir.is_dir():
+            raise RunnerError(f"FASTA directory is not a directory: {fasta_dir}")
+        if not dry_run and not fasta_dir.stat().st_mode:
+            raise RunnerError(f"Cannot inspect FASTA directory: {fasta_dir}")
+        if dry_run or os_access_writable(fasta_dir):
+            commands.append(f"samtools faidx {q(config.genome.fasta)}")
+            if not dry_run:
+                run_shell(commands[-1])
+        else:
+            raise RunnerError(
+                f"FASTA index not found or empty: {fai}. Create it first with: samtools faidx {q(config.genome.fasta)}"
+            )
+    commands.append(f"cut -f1,2 {q(fai)} > {q(target)}")
+    if not dry_run:
+        with open(fai, "r", encoding="utf-8") as source, open(target, "w", encoding="utf-8") as sink:
+            for line in source:
+                fields = line.rstrip("\n").split("\t")
+                if len(fields) >= 2:
+                    sink.write(f"{fields[0]}\t{fields[1]}\n")
+    return target, commands
+
+
+def os_access_writable(path: Path) -> bool:
+    import os
+
+    return os.access(path, os.W_OK)
+
+
+def build_metadata(config: PipelineConfig, chrom_sizes: Path, commands: list[str], *, dry_run: bool) -> dict[str, object]:
+    return {
+        "sample": config.sample,
+        "assay": config.assay,
+        "config_path": str(config.config_path),
+        "output_dir": str(config.sample_output_dir),
+        "genome_name": config.genome.name,
+        "genome_fasta": str(config.genome.fasta),
+        "chrom_sizes": str(chrom_sizes),
+        "fastq_r1": str(config.fastq_r1),
+        "fastq_r2": str(config.fastq_r2),
+        "threads": config.threads,
+        "bin_sizes": config.bin_sizes,
+        "outputs": {
+            "keep_bam": config.outputs.keep_bam,
+            "make_hic": config.outputs.make_hic,
+            "make_mcool": config.outputs.make_mcool,
+        },
+        "pipeline_version": __version__,
+        "dry_run": dry_run,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "commands": commands,
+    }
+
+
+def workflow_commands(config: PipelineConfig, dirs: dict[str, Path], chrom_sizes: Path) -> list[str]:
+    sample = config.sample
+    threads = config.threads
+    first_bin_size = config.bin_sizes[0]
+    repo_root = Path(__file__).resolve().parents[1]
+    get_qc = repo_root / "get_qc.py"
+
+    trim_dir = dirs["temp"] / "trimmed_fastq"
+    sample_temp = dirs["temp"] / sample
+    trimmed_r1 = trim_dir / trim_galore_output_name(config.fastq_r1, 1)
+    trimmed_r2 = trim_dir / trim_galore_output_name(config.fastq_r2, 2)
+    sam = sample_temp / f"{sample}.sam"
+    pairsam = sample_temp / f"{sample}.pairsam"
+    sorted_pairsam = sample_temp / f"{sample}.sorted.pairsam"
+    dedup_pairsam = sample_temp / f"{sample}.dedup.pairsam"
+    undedup_bam = dirs["bam"] / f"{sample}.undedup.bam"
+    undedup_pt_bam = dirs["bam"] / f"{sample}.undedup.PT.bam"
+    raw_bam = dirs["bam"] / f"{sample}.bam"
+    final_bam = dirs["bam"] / f"{sample}.PT.bam"
+    final_bai = Path(str(final_bam) + ".bai")
+    pairs = dirs["pairs"] / f"{sample}.pairs"
+    pairs_gz = Path(str(pairs) + ".gz")
+    cool = dirs["cool"] / f"{sample}.cool"
+
+    commands = [
+        f"mkdir -p {q(trim_dir)} {q(sample_temp)}",
+        f"fastqc -t {threads} -o {q(dirs['fastqc'])} {q(config.fastq_r1)} {q(config.fastq_r2)}",
+        f"trim_galore -j {threads} -o {q(trim_dir)} --paired {q(config.fastq_r1)} {q(config.fastq_r2)}",
+        f"bwa mem -5SP -T0 -t {threads} {q(config.genome.fasta)} {q(trimmed_r1)} {q(trimmed_r2)} -o {q(sam)}",
+        f"pairtools parse --min-mapq 40 --walks-policy 5unique --max-inter-align-gap 30 --nproc-in {threads} --nproc-out {threads} --chroms-path {q(chrom_sizes)} {q(sam)} > {q(pairsam)}",
+        f"pairtools sort --nproc {threads} --tmpdir={q(sample_temp)} {q(pairsam)} > {q(sorted_pairsam)}",
+        f"rm {q(pairsam)}",
+        f"pairtools split --nproc-in {threads} --nproc-out {threads} --output-sam {q(undedup_bam)} {q(sorted_pairsam)}",
+        f"samtools sort -@ {threads} -T {q(undedup_bam)} -o {q(undedup_pt_bam)} {q(undedup_bam)}",
+        f"rm {q(undedup_bam)}",
+        f"samtools index {q(undedup_pt_bam)}",
+        f"preseq lc_extrap -bam -pe -extrap 2.1e9 -step 1e8 -seg_len 1000000000 -output {q(dirs['stats'] / ('comp_' + sample + '.txt'))} {q(undedup_pt_bam)}",
+        f"rm {q(undedup_pt_bam)}",
+        f"pairtools dedup --nproc-in {threads} --nproc-out {threads} --mark-dups --output-stats {q(dirs['stats'] / (sample + '.txt'))} --output {q(dedup_pairsam)} {q(sorted_pairsam)}",
+        f"rm {q(sorted_pairsam)}",
+        f"python3 {q(get_qc)} -p {q(dirs['stats'] / (sample + '.txt'))} > {q(dirs['qc'] / ('qc_' + sample + '.txt'))}",
+        f"pairtools split --nproc-in {threads} --nproc-out {threads} --output-pairs {q(pairs)} --output-sam {q(raw_bam)} {q(dedup_pairsam)}",
+        f"rm {q(dedup_pairsam)}",
+        f"samtools sort -@ {threads} -T {q(raw_bam)} -o {q(final_bam)} {q(raw_bam)}",
+        f"rm {q(raw_bam)}",
+        f"samtools index {q(final_bam)}",
+    ]
+    if config.outputs.make_hic:
+        commands.append(f"juicer_tools pre -j {threads} {q(pairs)} {q(dirs['hic'] / (sample + '.hic'))} {q(config.genome.name)}")
+    commands.extend(
+        [
+            f"bgzip {q(pairs)}",
+            f"pairix {q(pairs_gz)}",
+            f"cooler cload pairix -p {threads} {q(str(chrom_sizes) + ':' + str(first_bin_size))} {q(pairs_gz)} {q(cool)}",
+        ]
+    )
+    if config.outputs.make_mcool:
+        commands.append(f"cooler zoomify -p {threads} {q(cool)}")
+    if not config.outputs.keep_bam:
+        commands.append(f"rm -f {q(final_bam)} {q(final_bai)}")
+    return commands
+
+
+def run_shell(command: str, log_handle=None) -> None:
+    if log_handle is not None:
+        print(f"$ {command}", file=log_handle, flush=True)
+    completed = subprocess.run(command, shell=True, stdout=log_handle, stderr=subprocess.STDOUT)
+    if completed.returncode != 0:
+        raise RunnerError(f"Command failed with exit code {completed.returncode}: {command}")
+
+
+def print_plan(config: PipelineConfig, chrom_commands: list[str], commands: list[str]) -> None:
+    print(f"Sample: {config.sample}")
+    print(f"Assay: {config.assay}")
+    print(f"Output directory: {config.sample_output_dir}")
+    print(f"Threads: {config.threads}")
+    if len(config.bin_sizes) > 1:
+        print(
+            "Warning: v0.4.0 uses only the first configured bin size for .cool generation: "
+            f"{config.bin_sizes[0]}"
+        )
+    print("Planned commands:")
+    for command in [*chrom_commands, *commands]:
+        print(command)
+
+
+def run_pipeline(config: PipelineConfig, *, dry_run: bool = False) -> None:
+    dry_dirs = {name: config.sample_output_dir / name for name in OUTPUT_SUBDIRS}
+    if dry_run:
+        dirs = dry_dirs
+    else:
+        check_dependencies(config)
+        dirs = ensure_output_dirs(config)
+    chrom_sizes, chrom_commands = derive_chrom_sizes(config, dirs, dry_run=dry_run)
+    commands = workflow_commands(config, dirs, chrom_sizes)
+    all_commands = [*chrom_commands, *commands]
+
+    if dry_run:
+        print_plan(config, chrom_commands, commands)
+        return
+
+    metadata = build_metadata(config, chrom_sizes, all_commands, dry_run=False)
+    metadata_path = config.sample_output_dir / "run_metadata.json"
+    metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+
+    log_path = dirs["logs"] / f"{config.sample}.log"
+    with open(log_path, "a", encoding="utf-8") as log_handle:
+        print(f"Sample: {config.sample}", file=log_handle)
+        print(f"Assay: {config.assay}", file=log_handle)
+        print(f"Config path: {config.config_path}", file=log_handle)
+        print(f"Output directory: {config.sample_output_dir}", file=log_handle)
+        print(f"Threads: {config.threads}", file=log_handle)
+        if len(config.bin_sizes) > 1:
+            print(
+                "Warning: v0.4.0 uses only the first configured bin size for .cool generation: "
+                f"{config.bin_sizes[0]}",
+                file=log_handle,
+            )
+        for command in chrom_commands:
+            print(f"$ {command}", file=log_handle, flush=True)
+        for command in commands:
+            run_shell(command, log_handle=log_handle)
+
+
+def validate_chrom_sizes_feasibility(config: PipelineConfig) -> None:
+    if config.genome.chrom_sizes is not None:
+        return
+    fai = Path(str(config.genome.fasta) + ".fai")
+    if fai.is_file() and fai.stat().st_size > 0:
+        return
+    if not os_access_writable(config.genome.fasta.parent):
+        raise ConfigError(
+            f"FASTA index not found or empty: {fai}; FASTA directory is not writable. "
+            f"Create the index first with: samtools faidx {q(config.genome.fasta)}"
+        )


### PR DESCRIPTION
### Motivation

- Provide a minimal, config-driven single-sample entrypoint to remove reliance on hard-coded FASTQ naming and manual edits to the legacy script. 
- Keep the repository Micro-C-first by default and avoid adding restriction-enzyme or restriction-fragment-aware behavior in v0.4.0. 
- Preserve the retained legacy `mdp.sh` workflow while adding a maintainable Python-based runner for single-sample use.

### Description

- Added a new CLI entrypoint `bin/microc-pipeline` with subcommands `run` (and `--dry-run`) and `validate-config`, implemented in `microc_pipeline/cli.py`. 
- Implemented config loading and validation in `microc_pipeline/config.py` including a small built-in YAML subset parser, required fields, defaults (e.g. `assay: microc`, `threads` fallback), checks for missing files, and clear error messages for unsupported `assay` values. 
- Implemented the runner in `microc_pipeline/runner.py` which constructs the same core Micro-C preprocessing command sequence (FastQC → Trim Galore → `bwa mem -5SP -T0` → pairtools parse/sort/dedup/split → samtools, preseq, bgzip/pairix, cooler, optional `juicer_tools`), supports dry-run printing, derives or copies chromosome sizes into `results/SAMPLE/genome/`, creates per-sample output dirs, and writes structured `run_metadata.json` (without any `enzyme` field). 
- Added `config/example.single-sample.yaml`, documentation `docs/configuration.md`, updated `README.md`, `docs/design.md`, `docs/outputs.md`, `docs/roadmap.md`, and `CHANGELOG.md`, and added `results/` to `.gitignore` so per-sample outputs are untracked.

### Testing

- Syntax and basic checks: ran `bash -n mdp.sh` and `python3 -m py_compile get_qc.py` and `python3 -m py_compile microc_pipeline/*.py`, all succeeded. 
- CLI help smoke tests: `bin/microc-pipeline --help`, `bin/microc-pipeline run --help`, and `bin/microc-pipeline validate-config --help` were exercised and returned expected help output. 
- Minimal config validation and dry-run: created a temporary minimal filesystem and config and ran `bin/microc-pipeline validate-config --config <tmpconfig>` and `bin/microc-pipeline run --config <tmpconfig> --dry-run`, and both succeeded and printed the planned command sequence without executing external tools. 
- Behavior checks: validation fails with an unsupported `assay` (for example `assay: hic`) and dependency checks report missing required commands when real execution is attempted, as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2669205ccc8327bbb26c6ae8e350f1)