### PR TITLE
v0.5.0: Standardize final outputs, add output validation and manifest, TSV QC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.5.0 - Unreleased
+
+### Added
+- Added standardized config-driven final output names for valid pairs, matrices, stats, QC, optional `.hic`, and optional BAM outputs.
+- Added `SAMPLE.valid.pairs.gz` as the first-class valid pairs output and `SAMPLE.valid.pairs.gz.px2` as its Pairix index.
+- Added explicit `SAMPLE.cool`, optional `SAMPLE.mcool`, and optional `SAMPLE.hic` final output paths.
+- Added `SAMPLE.pairtools.stats.txt`, `SAMPLE.preseq.lc_extrap.txt`, and `SAMPLE.qc.tsv` final stats/QC paths.
+- Added lightweight output validation for required final products.
+- Added `output_manifest.json` to record expected outputs and validation status.
+- Added `bin/microc-pipeline validate-outputs` for checking completed runs without rerunning preprocessing.
+- Added `get_qc.py --format tsv` while preserving the default text output.
+
+### Changed
+- Updated `run_metadata.json` content to include standardized final output paths and the output manifest path.
+- Updated README and documentation for v0.5.0 output semantics, validation, manifest behavior, and `.hic` file-format wording.
+
+### Notes
+- `.hic` is documented as the Juicer contact-map file format, not enzyme-aware Hi-C assay support.
+- Multi-sample execution, restartable chunk processing, workflow-manager files, containers, CI, full HTML QC reports, and enzyme-aware Hi-C behavior remain future work.
+
 ## v0.4.0 - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # microC-pipeline
 
-`microC-pipeline` is a Micro-C preprocessing repository. The v0.4.0 development milestone adds a lightweight config-driven single-sample entrypoint while retaining the historical `mdp.sh` Slurm script for backward compatibility.
+`microC-pipeline` is a Micro-C preprocessing repository. The v0.5.0 development milestone keeps the lightweight config-driven single-sample runner introduced in v0.4.0 and makes its valid pairs, matrix, stats, QC, and manifest files first-class validated products.
 
-The preferred v0.4.0 interface is:
+The preferred interface is:
 
 ```bash
 bin/microc-pipeline run --config config/example.single-sample.yaml
 ```
 
-The retained legacy interface remains:
+The retained legacy interface remains available for backward compatibility:
 
 ```bash
 sbatch --time=24:00:00 --cpus-per-task=16 --mem=64g \
   mdp.sh SAMPLE mm10 /path/to/mm10.fa
 ```
 
-This repository is still **not** a modern restartable workflow-manager pipeline. It does not implement restartable chunk-based execution, multi-sample sample sheets, Snakemake or Nextflow workflows, containers, CI, full HTML QC reports, or downstream biological interpretation.
+This repository is still **not** a modern restartable workflow-manager pipeline. It does not implement restartable chunk-based execution, multi-sample sample sheets, Snakemake or Nextflow workflows, containers, CI, full HTML QC reports, enzyme-aware Hi-C processing, restriction fragment generation, loop calling, compartment calling, TAD calling, differential contact analysis, or downstream biological interpretation.
 
 ## What this repository does
 
@@ -28,58 +28,52 @@ For one Micro-C sample, the config-driven runner follows the same core preproces
 5. Undeduplicated BAM split, sorting, and indexing.
 6. Library complexity estimation with Preseq.
 7. Pairtools deduplication and stats.
-8. A small QC text summary from `get_qc.py`.
-9. Final deduplicated pairs and BAM generation.
-10. Optional `.hic` generation with Juicer tools.
-11. `.pairs.gz`, Pairix index, `.cool`, and optional `.mcool` generation.
+8. Machine-readable QC TSV generation with `get_qc.py --format tsv`.
+9. Final deduplicated valid pairs and BAM generation.
+10. Optional Juicer `.hic` contact-map file generation.
+11. BGZF compression, Pairix indexing, `.cool`, and optional `.mcool` generation.
+12. Lightweight validation and `output_manifest.json` creation.
 
-The default workflow is Micro-C-oriented. No restriction enzyme is required, the v0.4.0 config does not include an enzyme field, and restriction-fragment-aware Hi-C processing is not implemented in this milestone.
+The default workflow is Micro-C-oriented. No restriction enzyme is required, the config does not include an enzyme field, and restriction-fragment-aware Hi-C processing is not implemented. The optional `.hic` output is the Juicer contact-map **file format**; it does not imply enzyme-aware Hi-C assay mode.
 
 ## Repository contents
 
 ```text
 README.md                         Project overview and usage notes
-bin/microc-pipeline               v0.4.0 config-driven single-sample CLI
-microc_pipeline/                  Python package for config validation and command execution
+bin/microc-pipeline               v0.5.0 config-driven single-sample CLI
+microc_pipeline/                  Python package for config, output paths, validation, and command execution
 config/example.single-sample.yaml Example single-sample Micro-C config
 config/README.md                  Configuration directory notes
-docs/configuration.md             v0.4.0 config reference
+docs/configuration.md             Config reference
 docs/design.md                    Design notes and current boundaries
-docs/outputs.md                   Current config-driven and legacy output notes
+docs/outputs.md                   Standardized output layout and manifest schema
 docs/roadmap.md                   Development roadmap
 mdp.sh                            Retained legacy/minimal Slurm Micro-C preprocessing script
-get_qc.py                         Small Pairtools-stats QC text summarizer
+get_qc.py                         Pairtools-stats QC summarizer with text and TSV output
 CHANGELOG.md                      Repository-level change history
 LICENSE                           MIT license
 examples/README.md                Placeholder for future tiny synthetic examples
 .gitignore                        Ignore rules for large genomics outputs and local files
 ```
 
-## Config-driven v0.4.0 usage
+## Config-driven usage
 
 Start from `config/example.single-sample.yaml`:
 
 ```yaml
 sample: SAMPLE_ID
-
 assay: microc
-
 fastq:
   r1: fastq/SAMPLE_R1.fastq.gz
   r2: fastq/SAMPLE_R2.fastq.gz
-
 genome:
   name: mm10
   fasta: /path/to/mm10.fa
   chrom_sizes: null
-
 threads: 16
-
 bin_sizes:
   - 1000
-
 output_dir: results
-
 outputs:
   keep_bam: true
   make_hic: true
@@ -92,7 +86,7 @@ Validate a config:
 bin/microc-pipeline validate-config --config config/example.single-sample.yaml
 ```
 
-Print planned commands without running external tools:
+Print planned commands, expected final outputs, and planned validation checks without running external tools:
 
 ```bash
 bin/microc-pipeline run --config config/example.single-sample.yaml --dry-run
@@ -104,28 +98,35 @@ Run one sample:
 bin/microc-pipeline run --config config/example.single-sample.yaml
 ```
 
-The runner requires explicit FASTQ paths in the config rather than the legacy hard-coded `fastq/{SAMPLE_ID}_R1_001.fastq.gz` and `fastq/{SAMPLE_ID}_R2_001.fastq.gz` names. See `docs/configuration.md` for required fields, defaults, dry-run behavior, genome FASTA index handling, and current limitations.
+Validate outputs from an existing completed run without rerunning preprocessing:
 
-## Config-driven output layout
+```bash
+bin/microc-pipeline validate-outputs --config config/example.single-sample.yaml
+```
 
-The v0.4.0 runner writes under a per-sample directory:
+See `docs/configuration.md` for required fields, defaults, dry-run behavior, genome FASTA index handling, output toggles, and current limitations.
+
+## Standardized final output layout
+
+The config-driven runner writes under a per-sample directory and validates the final products before reporting success:
 
 ```text
 results/SAMPLE/
-  bam/
-  cool/
-  fastqc/
-  hic/
-  genome/
-  logs/
-  pairs/
-  qc/
-  stats/
-  temp/
+  pairs/SAMPLE.valid.pairs.gz
+  pairs/SAMPLE.valid.pairs.gz.px2
+  cool/SAMPLE.cool
+  cool/SAMPLE.mcool              # when outputs.make_mcool: true
+  hic/SAMPLE.hic                 # when outputs.make_hic: true
+  stats/SAMPLE.pairtools.stats.txt
+  stats/SAMPLE.preseq.lc_extrap.txt
+  qc/SAMPLE.qc.tsv
+  bam/SAMPLE.PT.bam              # when outputs.keep_bam: true
+  bam/SAMPLE.PT.bam.bai          # when outputs.keep_bam: true
   run_metadata.json
+  output_manifest.json
 ```
 
-For real runs, `run_metadata.json` records the resolved sample, assay, config path, output directory, genome resources, FASTQ paths, threads, bin sizes, output toggles, pipeline version, dry-run status, timestamp, and command list. The metadata does not include restriction enzyme information.
+`run_metadata.json` records how the run was configured and executed, including standardized final output paths. `output_manifest.json` records which final outputs were expected and whether validation passed. Detailed output semantics, validation checks, and manifest fields are documented in `docs/outputs.md`.
 
 ## Requirements
 
@@ -168,41 +169,4 @@ sbatch --time=24:00:00 --cpus-per-task=16 --mem=64g \
   mdp.sh <SAMPLE_ID> <GENOME_NAME> <GENOME_FASTA>
 ```
 
-Example:
-
-```bash
-sbatch --time=24:00:00 --cpus-per-task=16 --mem=64g \
-  mdp.sh SAMPLE mm10 /path/to/mm10.fa
-```
-
-Arguments:
-
-- `SAMPLE_ID`: sample prefix matching FASTQs under `fastq/`.
-- `GENOME_NAME`: short genome label used for generated files and Juicer tools, for example `mm10` or `hg38`.
-- `GENOME_FASTA`: path to the reference FASTA.
-
-Threading defaults to `SLURM_CPUS_PER_TASK` when set, otherwise `16`.
-
-The legacy script creates and uses root-level directories such as `BAM/`, `cool/`, `fastqc/`, `hic/`, `genome/`, `pairs/`, `stats/`, `temp/`, and `logs/`.
-
-## QC summary
-
-After Pairtools deduplication, both workflows can create a compact text summary from Pairtools stats with `get_qc.py`:
-
-```bash
-python3 get_qc.py -p stats/SAMPLE.txt > stats/qc_SAMPLE.txt
-```
-
-The config-driven runner writes its QC summary under `results/SAMPLE/qc/`.
-
-## Notes and limitations
-
-- v0.4.0 supports only one sample per config/run command.
-- Multi-sample support is not implemented yet.
-- Restartable chunk-based processing is not implemented yet.
-- The repository does not include workflow-manager files, containers, CI, full QC reports, or project-level QC summaries.
-- The default workflow is Micro-C-oriented and does not require restriction enzyme information.
-- Enzyme-aware Hi-C processing, restriction fragment generation, and `pairtools restrict` are not implemented.
-- Downstream loop calling, compartment calling, TAD calling, differential contact analysis, and biological interpretation are outside the current scope.
-
-Large genomics outputs and inputs are ignored by Git so the public repository stays small and safe.
+The v0.5.0 standardized output naming and validation layer apply to the config-driven runner, not to the retained legacy root-level layout.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,133 +1,86 @@
-# Configuration guide
+# Configuration
 
-The v0.4.0 workflow adds a small config-driven interface for one Micro-C sample:
+The config-driven runner accepts one YAML file for one Micro-C sample:
 
 ```bash
 bin/microc-pipeline run --config config/example.single-sample.yaml
 ```
 
-Use `validate-config` before running a full preprocessing job:
+Validate configuration without running preprocessing:
 
 ```bash
 bin/microc-pipeline validate-config --config config/example.single-sample.yaml
 ```
 
-Use dry-run mode to print the planned command sequence without running external tools or creating large outputs:
+Validate outputs from an existing completed run. This command uses the config only to infer expected output paths and toggles, so it does not require the original FASTQs or genome FASTA to still be present:
 
 ```bash
-bin/microc-pipeline run --config config/example.single-sample.yaml --dry-run
+bin/microc-pipeline validate-outputs --config config/example.single-sample.yaml
 ```
 
-The v0.4.0 workflow is Micro-C-oriented and does not require restriction enzyme information. Restriction-fragment-aware Hi-C behavior may be considered in a future milestone, but it is not implemented now.
-
-## Example config
+## Example
 
 ```yaml
 sample: SAMPLE_ID
-
 assay: microc
-
 fastq:
   r1: fastq/SAMPLE_R1.fastq.gz
   r2: fastq/SAMPLE_R2.fastq.gz
-
 genome:
   name: mm10
   fasta: /path/to/mm10.fa
   chrom_sizes: null
-
 threads: 16
-
 bin_sizes:
   - 1000
-
 output_dir: results
-
 outputs:
   keep_bam: true
   make_hic: true
   make_mcool: true
 ```
 
-Path values are interpreted by the command shell from the directory where you run `bin/microc-pipeline`. Absolute paths are recommended for shared genome resources.
+## Fields
 
-## Required fields
+| Field | Required | Default | Description |
+| --- | --- | --- | --- |
+| `sample` | Yes | None | Sample identifier used in the per-sample output directory and standardized output names. |
+| `assay` | No | `microc` | Only `microc` is supported. No enzyme-aware Hi-C mode is implemented. |
+| `fastq.r1` | Yes | None | R1 FASTQ path. |
+| `fastq.r2` | Yes | None | R2 FASTQ path. |
+| `genome.name` | Yes | None | Genome label passed to tools that need a genome name. |
+| `genome.fasta` | Yes | None | Reference FASTA path. BWA indexes should already exist. |
+| `genome.chrom_sizes` | No | `null` | Optional chromosome sizes file. If omitted, the runner uses `genome.fasta.fai` or creates it with `samtools faidx` when the FASTA directory is writable. |
+| `threads` | No | `$SLURM_CPUS_PER_TASK` or `16` | Positive integer thread count. |
+| `bin_sizes` | No | `[1000]` | Positive integer bin sizes. v0.5.0 uses the first value for `.cool`; optional `.mcool` is produced by `cooler zoomify`. |
+| `output_dir` | Yes | None | Root output directory. Final outputs are under `output_dir/sample`. |
+| `outputs.keep_bam` | No | `true` | Retain and validate `bam/SAMPLE.PT.bam` and `bam/SAMPLE.PT.bam.bai`. If false, final BAM files are removed and are not expected by validation. |
+| `outputs.make_hic` | No | `true` | Create and validate `hic/SAMPLE.hic`. This is the Juicer contact-map file format, not enzyme-aware Hi-C assay support. |
+| `outputs.make_mcool` | No | `true` | Create and validate `cool/SAMPLE.mcool`. |
 
-| Field | Meaning |
-| --- | --- |
-| `sample` | Single sample identifier used for the per-sample output directory and output filenames. |
-| `fastq.r1` | Explicit path to read 1 FASTQ. |
-| `fastq.r2` | Explicit path to read 2 FASTQ. |
-| `genome.name` | Short genome label, for example `mm10` or `hg38`. |
-| `genome.fasta` | Path to the reference FASTA. BWA indexes must already be available for alignment. |
-| `output_dir` | Root output directory. The workflow writes to `output_dir/sample`. |
+## Output toggles and validation
 
-## Optional fields and defaults
+The output toggles define both the commands that are planned and the final files expected by validation:
 
-| Field | Default | Meaning |
-| --- | --- | --- |
-| `assay` | `microc` | v0.4.0 supports only `microc`. Unsupported values fail clearly. |
-| `genome.chrom_sizes` | `null` | Optional chromosome sizes file. If absent or null, the runner derives chromosome sizes from `${genome.fasta}.fai`. |
-| `threads` | `SLURM_CPUS_PER_TASK`, otherwise `16` | Thread count passed to supported tools. |
-| `bin_sizes` | `[1000]` | Configured contact matrix bin sizes. v0.4.0 uses only the first value for `.cool` generation and warns when more are provided. |
-| `outputs.keep_bam` | `true` | Keep or remove the final `bam/SAMPLE.PT.bam` and index after downstream outputs are created. |
-| `outputs.make_hic` | `true` | Run `juicer_tools pre` to create `hic/SAMPLE.hic`. |
-| `outputs.make_mcool` | `true` | Run `cooler zoomify` to create a multiresolution Cooler output. |
+- `outputs.keep_bam: true` makes `bam/SAMPLE.PT.bam` and `bam/SAMPLE.PT.bam.bai` required final outputs.
+- `outputs.keep_bam: false` removes final BAM products after downstream outputs are produced; BAM files are skipped by output validation.
+- `outputs.make_hic: true` makes `hic/SAMPLE.hic` a required validated output.
+- `outputs.make_hic: false` skips `.hic` creation and validation.
+- `outputs.make_mcool: true` makes `cool/SAMPLE.mcool` a required validated output.
+- `outputs.make_mcool: false` skips `.mcool` creation and validation.
 
-## Assay behavior
+Always-required final outputs are the BGZF-compressed valid pairs file, Pairix index, `.cool`, Pairtools stats, Preseq output, QC TSV, `run_metadata.json`, and `output_manifest.json`.
 
-If `assay` is omitted, the runner treats the sample as Micro-C:
+## Dry run
 
-```yaml
-assay: microc
+Dry-run mode prints planned commands, expected final outputs, and planned validation checks without validating files:
+
+```bash
+bin/microc-pipeline run --config config/example.single-sample.yaml --dry-run
 ```
 
-No `hic` assay mode is implemented in v0.4.0. For example, `assay: hic` fails with:
+Dry-run mode is intended for inspection. It may create no files at all.
 
-```text
-Unsupported assay: hic. v0.4.0 supports only assay: microc.
-```
+## Boundaries
 
-## Genome FASTA index and chromosome sizes
-
-The runner uses `genome.fasta` as the reference FASTA. If `genome.chrom_sizes` is provided, that file is copied into the sample output directory. If `genome.chrom_sizes` is absent or null, the runner requires a non-empty `${genome.fasta}.fai`, or creates one with `samtools faidx` when the FASTA directory is writable.
-
-For real runs, the workflow writes the chromosome sizes file to:
-
-```text
-results/SAMPLE/genome/{genome.name}.chrom.sizes
-```
-
-That file is used by Pairtools and Cooler.
-
-## Output directory behavior
-
-The config-driven workflow writes under a per-sample directory:
-
-```text
-results/SAMPLE/
-  bam/
-  cool/
-  fastqc/
-  hic/
-  genome/
-  logs/
-  pairs/
-  qc/
-  stats/
-  temp/
-  run_metadata.json
-```
-
-If `output_dir: .` is set explicitly, the per-sample directory is created in the current directory as `./SAMPLE/`. The retained legacy `mdp.sh` script continues to use its historical repository-root output directories.
-
-## Current limitations
-
-- v0.4.0 supports one sample per command.
-- Multi-sample sample sheets are not implemented.
-- Restartable chunk-based execution is not implemented.
-- Snakemake and Nextflow workflow-manager implementations are not included.
-- Containers and CI are not included.
-- Full HTML QC reports and project-level QC summaries are not included.
-- Restriction-fragment-aware Hi-C behavior, restriction fragment generation, and `pairtools restrict` are not implemented.
-- Loop calling, compartment calling, TAD calling, differential contact analysis, and biological interpretation are outside the preprocessing scope.
+The config format is intentionally single-sample and Micro-C-first. It does not include a sample sheet, restart/resume settings, workflow-manager settings, container settings, restriction enzyme fields, restriction fragment files, or downstream biological interpretation options.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,35 +1,50 @@
 # Design notes
 
-This document records current design assumptions for `microC-pipeline` as the repository moves through the v0.4.0 config-driven single-sample milestone.
+## Current design
 
-## Current implementation status
+`microC-pipeline` currently has two interfaces:
 
-- `bin/microc-pipeline` provides a lightweight config-driven single-sample Micro-C entrypoint.
-- `mdp.sh` remains the retained legacy/minimal Slurm script for backward compatibility.
-- The config-driven runner removes the legacy need to edit hard-coded FASTQ names by accepting explicit `fastq.r1` and `fastq.r2` paths in YAML.
-- The current runnable workflows remain single-sample oriented.
-- Restartable chunk-based execution is not available in the current repository.
-- Multi-sample sample-sheet orchestration is not implemented.
-- Snakemake and Nextflow engines are not implemented.
+1. A retained legacy Slurm script, `mdp.sh`, kept for backward compatibility.
+2. A lightweight config-driven single-sample runner, `bin/microc-pipeline`, for modernized Micro-C preprocessing.
 
-## v0.4.0 design boundary
+The v0.5.0 milestone keeps the v0.4.0 single-sample runner model and makes final valid pairs, matrix, stats, QC, and manifest files first-class products. It adds standardized names, output validation, `output_manifest.json`, and a `validate-outputs` command.
 
-The v0.4.0 implementation is intentionally small. It validates one YAML config, creates one per-sample output directory, derives or copies chromosome sizes, writes structured metadata, and executes the same core Micro-C preprocessing path as the legacy script.
+## Micro-C-first boundary
 
-The default workflow is Micro-C-oriented and does not require restriction enzyme information. Restriction-fragment-aware Hi-C behavior may be considered in a future milestone, but v0.4.0 does not implement restriction fragment generation, `pairtools restrict`, or enzyme-aware processing.
+The runner is Micro-C-first:
 
-## Engine direction planning note
+- no restriction enzyme field is required or accepted as a workflow concept;
+- no restriction fragments are generated;
+- `pairtools restrict` is not run;
+- enzyme-aware Hi-C processing is not implemented.
 
-No final engine choice has been made for a future production-facing workflow.
+Optional `.hic` output is only the Juicer contact-map file format. It does not indicate Hi-C assay mode.
 
-Candidate future directions include:
+## What v0.5.0 deliberately does not add
 
-- **Bash-first**: keep the implementation close to the existing script while adding stronger structure, validation, and restart behavior.
-- **Snakemake**: use a rule-based workflow manager with explicit inputs, outputs, and cluster execution support.
-- **Nextflow**: use a process-based workflow manager with strong portability patterns for local, HPC, and containerized execution.
+The v0.5.0 output milestone does **not** add:
 
-HiC-Nap restartable chunk-processing concepts are expected to inform future development, especially FASTQ chunking, per-chunk status tracking, conservative restart behavior, global merge/deduplication, and progress logging. Those concepts are planning inputs only in this repository today; they are not implemented here yet.
+- multi-sample sample-sheet execution;
+- restartable chunk-based execution;
+- Snakemake or Nextflow workflows;
+- containers;
+- CI;
+- full HTML QC reports;
+- project-level QC summaries;
+- enzyme-aware Hi-C behavior;
+- restriction fragment generation;
+- `pairtools restrict`;
+- loop, compartment, TAD, or differential contact analysis;
+- downstream biological interpretation.
 
-## Near-term design boundaries
+These remain future milestones.
 
-Near-term work should avoid turning v0.4.0 into a large framework. Later milestones may standardize valid pairs and matrix outputs, add restartable chunk execution, choose a workflow engine, add sample-sheet support, improve QC, and introduce packaging or containers.
+## Metadata and manifest split
+
+`run_metadata.json` records how a run was configured and executed: config path, inputs, genome resources, threads, commands, output toggles, and standardized final output paths.
+
+`output_manifest.json` records what final outputs were expected and whether lightweight validation passed. Keeping these concerns separate makes output inspection possible without treating execution provenance as validation state.
+
+## Future direction
+
+Future milestones may add restartability, multi-sample orchestration, workflow-manager integrations, richer QC, packaging, tests, and deeper validators. Those changes should preserve the v0.5.0 final output names where possible.

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -1,65 +1,22 @@
-# Output notes
+# Outputs
 
-This document distinguishes the current v0.4.0 config-driven output layout from retained legacy `mdp.sh` outputs and future planned outputs.
+This document describes the v0.5.0 standardized output layout for the config-driven single-sample runner and the retained legacy `mdp.sh` layout.
 
-## Current config-driven outputs
+## Scope
 
-The preferred v0.4.0 single-sample runner writes outputs under `output_dir/sample`. With the example `output_dir: results` and `sample: SAMPLE`, the layout is:
+The v0.5.0 output standardization applies to:
 
-```text
-results/SAMPLE/
-  bam/
-  cool/
-  fastqc/
-  hic/
-  genome/
-  logs/
-  pairs/
-  qc/
-  stats/
-  temp/
-  run_metadata.json
+```bash
+bin/microc-pipeline run --config config/example.single-sample.yaml
 ```
 
-Directory roles:
+It does not change the retained legacy `mdp.sh` output layout.
 
-- `bam/`: undeduplicated and final sorted/indexed BAM files. If `outputs.keep_bam: false`, the final `SAMPLE.PT.bam` and `.bai` are removed after downstream files are created.
-- `cool/`: first-bin `.cool` output and optional zoomified `.mcool` output.
-- `fastqc/`: FastQC outputs.
-- `hic/`: optional `SAMPLE.hic` when `outputs.make_hic: true`.
-- `genome/`: copied or derived `{genome.name}.chrom.sizes` file used by Pairtools and Cooler.
-- `logs/`: per-sample log file with resolved settings and command lines.
-- `pairs/`: deduplicated pairs, BGZF-compressed pairs, and Pairix index.
-- `qc/`: compact QC text summary produced by `get_qc.py`.
-- `stats/`: Pairtools stats and Preseq complexity output.
-- `temp/`: intermediate SAM, pairsam, and trimmed FASTQ files.
-- `run_metadata.json`: structured run metadata for real runs.
+The config-driven runner is Micro-C-first. It does not require restriction enzyme information, does not generate restriction fragments, and does not run `pairtools restrict`. Optional `.hic` output means the Juicer contact-map file format only; it is not a separate enzyme-aware Hi-C assay mode.
 
-The v0.4.0 runner always creates `.cool` for the first configured bin size. If multiple `bin_sizes` are configured, it warns that only the first value is used. It creates `.hic` only when `outputs.make_hic: true` and runs `cooler zoomify` only when `outputs.make_mcool: true`.
+## Final output layout
 
-`run_metadata.json` includes sample, assay, config path, output directory, genome FASTA, chromosome sizes path, FASTQ paths, thread count, bin sizes, output toggles, pipeline version, dry-run status, timestamp, and command records. It does not include restriction enzyme information.
-
-## Retained legacy `mdp.sh` outputs
-
-The retained legacy/minimal Slurm script writes outputs and intermediates into repository-root directories such as:
-
-```text
-BAM/
-cool/
-fastqc/
-hic/
-genome/
-pairs/
-stats/
-temp/
-logs/
-```
-
-These paths reflect the historical direct script workflow. They are kept for backward compatibility and are separate from the v0.4.0 per-sample `results/SAMPLE/` layout.
-
-## Future planned outputs
-
-Later milestones may standardize final valid pairs and matrix products as first-class outputs, validate output files, and add richer QC files. A candidate future layout remains:
+For a sample named `SAMPLE` and `output_dir: results`, final products are written under `results/SAMPLE/`:
 
 ```text
 results/SAMPLE/
@@ -69,7 +26,176 @@ results/SAMPLE/
   cool/SAMPLE.mcool
   hic/SAMPLE.hic
   stats/SAMPLE.pairtools.stats.txt
+  stats/SAMPLE.preseq.lc_extrap.txt
   qc/SAMPLE.qc.tsv
+  run_metadata.json
+  output_manifest.json
 ```
 
-Optional future outputs may include retained final BAM files under `results/SAMPLE/bam/`. Restartable chunk outputs, project-level QC summaries, and full reports remain future work.
+Optional final BAM products are retained only when `outputs.keep_bam: true`:
+
+```text
+results/SAMPLE/
+  bam/SAMPLE.PT.bam
+  bam/SAMPLE.PT.bam.bai
+```
+
+When `outputs.keep_bam: false`, the final BAM and BAI are removed after downstream commands complete. They are not required by output validation in that mode.
+
+## Final products
+
+| Product | Path | Controlled by | Notes |
+| --- | --- | --- | --- |
+| Valid pairs | `pairs/SAMPLE.valid.pairs.gz` | Always expected | BGZF-compressed deduplicated valid pairs. |
+| Pairix index | `pairs/SAMPLE.valid.pairs.gz.px2` | Always expected | Pairix index for the valid pairs file. |
+| Cooler matrix | `cool/SAMPLE.cool` | Always expected | Created with the first configured bin size. |
+| Multi-resolution cooler | `cool/SAMPLE.mcool` | `outputs.make_mcool` | Created with explicit `cooler zoomify -o cool/SAMPLE.mcool`. |
+| Juicer contact map | `hic/SAMPLE.hic` | `outputs.make_hic` | Juicer `.hic` file format, not enzyme-aware Hi-C mode. |
+| Pairtools stats | `stats/SAMPLE.pairtools.stats.txt` | Always expected | Deduplication stats used by `get_qc.py`. |
+| Preseq complexity | `stats/SAMPLE.preseq.lc_extrap.txt` | Always expected | `preseq lc_extrap` output. |
+| QC TSV | `qc/SAMPLE.qc.tsv` | Always expected | Machine-readable QC summary with `metric`, `value`, and `percent` columns. |
+| Final BAM | `bam/SAMPLE.PT.bam` | `outputs.keep_bam` | Deduplicated final BAM. |
+| Final BAM index | `bam/SAMPLE.PT.bam.bai` | `outputs.keep_bam` | BAI for final BAM. |
+
+## Temporary and intermediate files
+
+The runner may create temporary files under these directories while commands are executing:
+
+```text
+results/SAMPLE/temp/
+results/SAMPLE/bam/
+results/SAMPLE/pairs/
+```
+
+Examples include trimmed FASTQs, SAM, Pairtools `.pairsam` intermediates, undeduplicated BAM files, an uncompressed `pairs/SAMPLE.valid.pairs`, and raw BAM files. These are implementation details and should not be treated as stable final products.
+
+## Output validation
+
+A real `run` validates expected final outputs before printing success. The same checks can be run against an existing output directory without rerunning preprocessing:
+
+```bash
+bin/microc-pipeline validate-outputs --config config/example.single-sample.yaml
+```
+
+Validation is intentionally lightweight and conservative. It checks file presence, non-empty sizes, and small format indicators needed by this repository. It does not prove biological correctness.
+
+Required checks are:
+
+- `pairs/SAMPLE.valid.pairs.gz` exists and is greater than zero bytes.
+- `pairs/SAMPLE.valid.pairs.gz.px2` exists and is greater than zero bytes.
+- `cool/SAMPLE.cool` exists and is greater than zero bytes.
+- `cool/SAMPLE.mcool` exists and is greater than zero bytes when `outputs.make_mcool: true`.
+- `hic/SAMPLE.hic` exists and is greater than zero bytes when `outputs.make_hic: true`.
+- `stats/SAMPLE.pairtools.stats.txt` exists, is greater than zero bytes, and includes the Pairtools stats keys needed by `get_qc.py`.
+- `stats/SAMPLE.preseq.lc_extrap.txt` exists and is greater than zero bytes.
+- `qc/SAMPLE.qc.tsv` exists, is greater than zero bytes, and has header columns `metric`, `value`, and `percent`.
+- `bam/SAMPLE.PT.bam` and `bam/SAMPLE.PT.bam.bai` exist and are greater than zero bytes when `outputs.keep_bam: true`.
+
+The current validation layer does not require deep optional checks such as `cooler info`, `cooler ls`, `pairix -l`, or `samtools quickcheck`; those may be added later as best-effort checks.
+
+## `output_manifest.json`
+
+`output_manifest.json` records expected and observed final outputs. It is written after a real run validates outputs and is also updated by `validate-outputs`.
+
+Representative schema:
+
+```json
+{
+  "sample": "SAMPLE",
+  "assay": "microc",
+  "output_dir": "results/SAMPLE",
+  "pipeline_version": "v0.5.0-dev",
+  "outputs": {
+    "valid_pairs": {
+      "path": "results/SAMPLE/pairs/SAMPLE.valid.pairs.gz",
+      "index": "results/SAMPLE/pairs/SAMPLE.valid.pairs.gz.px2",
+      "required": true,
+      "validated": true,
+      "checks": {
+        "path": {"exists": true, "size_bytes": 12345},
+        "index": {"exists": true, "size_bytes": 678}
+      }
+    },
+    "cool": {
+      "path": "results/SAMPLE/cool/SAMPLE.cool",
+      "required": true,
+      "validated": true
+    },
+    "mcool": {
+      "path": "results/SAMPLE/cool/SAMPLE.mcool",
+      "required": true,
+      "validated": true
+    },
+    "hic": {
+      "path": "results/SAMPLE/hic/SAMPLE.hic",
+      "required": true,
+      "validated": true,
+      "note": "Juicer .hic contact-map file format; not enzyme-aware Hi-C assay mode."
+    },
+    "pairtools_stats": {
+      "path": "results/SAMPLE/stats/SAMPLE.pairtools.stats.txt",
+      "required": true,
+      "validated": true
+    },
+    "preseq": {
+      "path": "results/SAMPLE/stats/SAMPLE.preseq.lc_extrap.txt",
+      "required": true,
+      "validated": true
+    },
+    "qc_tsv": {
+      "path": "results/SAMPLE/qc/SAMPLE.qc.tsv",
+      "required": true,
+      "validated": true
+    },
+    "bam": {
+      "path": "results/SAMPLE/bam/SAMPLE.PT.bam",
+      "index": "results/SAMPLE/bam/SAMPLE.PT.bam.bai",
+      "required": true,
+      "validated": true
+    }
+  }
+}
+```
+
+If a toggle disables an optional output, the manifest keeps an entry with `required: false`, `expected: false`, and a skipped validation result.
+
+## `run_metadata.json`
+
+`run_metadata.json` records how the run was configured and executed. It includes sample, assay, config path, genome resources, FASTQ paths, thread count, bin sizes, output toggles, pipeline version, timestamp, commands, and a `final_outputs` mapping. It does not include restriction enzyme information.
+
+`run_metadata.json` is about execution provenance. `output_manifest.json` is about expected and validated products.
+
+## QC summary formats
+
+`get_qc.py` remains backward compatible. Its default output is the historical text table:
+
+```bash
+python3 get_qc.py -p stats/SAMPLE.pairtools.stats.txt --format text
+```
+
+The config-driven runner uses the new TSV mode:
+
+```bash
+python3 get_qc.py -p stats/SAMPLE.pairtools.stats.txt --format tsv
+```
+
+The TSV header is:
+
+```text
+metric	value	percent
+```
+
+## Retained legacy `mdp.sh` outputs
+
+The retained legacy script remains available:
+
+```bash
+sbatch --time=24:00:00 --cpus-per-task=16 --mem=64g \
+  mdp.sh SAMPLE mm10 /path/to/mm10.fa
+```
+
+It uses historical root-level directories such as `fastqc/`, `BAM/`, `pairs/`, `cool/`, `hic/`, `stats/`, and `qc/`, plus historical naming. The v0.5.0 `output_manifest.json`, standardized names, and `validate-outputs` command are for the config-driven runner.
+
+## Future planned output improvements
+
+Later milestones may add deeper external validators, full QC reports, project-level summaries, restartable execution, multi-sample manifests, and workflow-manager integrations. Those are intentionally outside v0.5.0.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -205,6 +205,7 @@ results/SAMPLE/
   cool/SAMPLE.mcool
   hic/SAMPLE.hic
   stats/SAMPLE.pairtools.stats.txt
+  stats/SAMPLE.preseq.lc_extrap.txt
   qc/SAMPLE.qc.tsv
 ```
 
@@ -216,13 +217,13 @@ results/SAMPLE/
   bam/SAMPLE.PT.bam.bai
 ```
 
-Planned tasks:
+Completed v0.5.0 tasks:
 
-- Standardize valid pairs output naming.
-- Ensure valid pairs are BGZF-compressed and pairix-indexed.
-- Add output validation for pairs, pairix index, cool, mcool, and hic where feasible.
-- Add optional BAM retention via config.
-- Document all outputs in `docs/outputs.md`.
+- [x] Standardized valid pairs output naming as `pairs/SAMPLE.valid.pairs.gz`.
+- [x] Ensured valid pairs are BGZF-compressed and pairix-indexed as `pairs/SAMPLE.valid.pairs.gz.px2`.
+- [x] Added output validation for pairs, pairix index, cool, mcool, hic, stats, QC TSV, and optional BAM where feasible.
+- [x] Added optional BAM retention via `outputs.keep_bam`.
+- [x] Documented all standardized outputs, validation checks, and the manifest schema in `docs/outputs.md`.
 
 Expected status after this milestone:
 

--- a/get_qc.py
+++ b/get_qc.py
@@ -19,13 +19,19 @@ REQUIRED_KEYS = (
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Create a compact text QC summary from pairtools stats output."
+        description="Create a compact QC summary from pairtools stats output."
     )
     parser.add_argument(
         "-p",
         "--pairtools-stats",
         required=True,
-        help="Pairtools stats output file, for example stats/SAMPLE.txt",
+        help="Pairtools stats output file, for example stats/SAMPLE.pairtools.stats.txt",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "tsv"),
+        default="text",
+        help="Output format. Default: text (legacy-compatible).",
     )
     return parser.parse_args()
 
@@ -51,16 +57,72 @@ def require_int(stats, key):
         sys.exit(1)
 
 
-def percent(numerator, denominator):
+def percent_value(numerator, denominator):
     if denominator == 0:
         return "NA"
-    return f"{round(numerator * 100.0 / denominator, 2)}%"
+    return str(round(numerator * 100.0 / denominator, 2))
+
+
+def percent(numerator, denominator):
+    value = percent_value(numerator, denominator)
+    if value == "NA":
+        return value
+    return f"{value}%"
 
 
 def print_table(table):
     widths = [max(len(row[index]) for row in table) for index in range(3)]
     for row in table:
         print("  ".join(value.ljust(widths[index]) for index, value in enumerate(row)))
+
+
+def qc_rows(stats):
+    total_reads = require_int(stats, "total")
+    unmapped_reads = require_int(stats, "total_unmapped")
+    mapped_reads = require_int(stats, "total_mapped")
+    dup_reads = require_int(stats, "total_dups")
+    nodup_reads = require_int(stats, "total_nodups")
+    cis_reads = require_int(stats, "cis")
+    trans_reads = require_int(stats, "trans")
+    cis_gt1kb = require_int(stats, "cis_1kb+")
+    cis_gt10kb = require_int(stats, "cis_10kb+")
+
+    cis_lt1kb = cis_reads - cis_gt1kb
+    valid_read_pairs = trans_reads + cis_gt1kb
+
+    return [
+        ("total_read_pairs", total_reads, "100" if total_reads else "NA", "Total Read Pairs", total_reads),
+        ("unmapped_read_pairs", unmapped_reads, percent_value(unmapped_reads, total_reads), "Unmapped Read Pairs", unmapped_reads),
+        ("mapped_read_pairs", mapped_reads, percent_value(mapped_reads, total_reads), "Mapped Read Pairs", mapped_reads),
+        ("pcr_dup_read_pairs", dup_reads, percent_value(dup_reads, total_reads), "PCR Dup Read Pairs", dup_reads),
+        ("no_dup_read_pairs", nodup_reads, percent_value(nodup_reads, total_reads), "No-Dup Read Pairs", nodup_reads),
+        ("no_dup_cis_read_pairs", cis_reads, percent_value(cis_reads, nodup_reads), "No-Dup Cis Read Pairs", cis_reads),
+        ("no_dup_trans_read_pairs", trans_reads, percent_value(trans_reads, nodup_reads), "No-Dup Trans Read Pairs", trans_reads),
+        (
+            "no_dup_valid_read_pairs_cis_ge_1kb_plus_trans",
+            valid_read_pairs,
+            percent_value(valid_read_pairs, nodup_reads),
+            "No-Dup Valid Read Pairs (cis >= 1kb + trans)",
+            valid_read_pairs,
+        ),
+        ("no_dup_cis_read_pairs_lt_1kb", cis_lt1kb, percent_value(cis_lt1kb, nodup_reads), "No-Dup Cis Read Pairs < 1kb", cis_lt1kb),
+        ("no_dup_cis_read_pairs_ge_1kb", cis_gt1kb, percent_value(cis_gt1kb, nodup_reads), "No-Dup Cis Read Pairs >= 1kb", cis_gt1kb),
+        ("no_dup_cis_read_pairs_ge_10kb", cis_gt10kb, percent_value(cis_gt10kb, nodup_reads), "No-Dup Cis Read Pairs >= 10kb", cis_gt10kb),
+    ]
+
+
+def print_text(rows):
+    table = []
+    for _, _, pct, label, value in rows:
+        text_pct = pct if pct == "NA" else f"{pct}%"
+        table.append([label, format(value, ",d"), text_pct])
+    print_table(table)
+
+
+def print_tsv(rows):
+    print("metric\tvalue\tpercent")
+    for metric, value, pct, _, _ in rows:
+        print(f"{metric}\t{value}\t{pct}")
 
 
 def main():
@@ -75,37 +137,11 @@ def main():
         )
         sys.exit(1)
 
-    total_reads = require_int(stats, "total")
-    unmapped_reads = require_int(stats, "total_unmapped")
-    mapped_reads = require_int(stats, "total_mapped")
-    dup_reads = require_int(stats, "total_dups")
-    nodup_reads = require_int(stats, "total_nodups")
-    cis_reads = require_int(stats, "cis")
-    trans_reads = require_int(stats, "trans")
-    cis_gt1kb = require_int(stats, "cis_1kb+")
-    cis_gt10kb = require_int(stats, "cis_10kb+")
-
-    cis_lt1kb = cis_reads - cis_gt1kb
-    valid_read_pairs = trans_reads + cis_gt1kb
-
-    table = [
-        ["Total Read Pairs", format(total_reads, ",d"), "100%" if total_reads else "NA"],
-        ["Unmapped Read Pairs", format(unmapped_reads, ",d"), percent(unmapped_reads, total_reads)],
-        ["Mapped Read Pairs", format(mapped_reads, ",d"), percent(mapped_reads, total_reads)],
-        ["PCR Dup Read Pairs", format(dup_reads, ",d"), percent(dup_reads, total_reads)],
-        ["No-Dup Read Pairs", format(nodup_reads, ",d"), percent(nodup_reads, total_reads)],
-        ["No-Dup Cis Read Pairs", format(cis_reads, ",d"), percent(cis_reads, nodup_reads)],
-        ["No-Dup Trans Read Pairs", format(trans_reads, ",d"), percent(trans_reads, nodup_reads)],
-        [
-            "No-Dup Valid Read Pairs (cis >= 1kb + trans)",
-            format(valid_read_pairs, ",d"),
-            percent(valid_read_pairs, nodup_reads),
-        ],
-        ["No-Dup Cis Read Pairs < 1kb", format(cis_lt1kb, ",d"), percent(cis_lt1kb, nodup_reads)],
-        ["No-Dup Cis Read Pairs >= 1kb", format(cis_gt1kb, ",d"), percent(cis_gt1kb, nodup_reads)],
-        ["No-Dup Cis Read Pairs >= 10kb", format(cis_gt10kb, ",d"), percent(cis_gt10kb, nodup_reads)],
-    ]
-    print_table(table)
+    rows = qc_rows(stats)
+    if args.format == "tsv":
+        print_tsv(rows)
+    else:
+        print_text(rows)
 
 
 if __name__ == "__main__":

--- a/microc_pipeline/__init__.py
+++ b/microc_pipeline/__init__.py
@@ -1,3 +1,3 @@
 """Lightweight config-driven Micro-C preprocessing entrypoint."""
 
-__version__ = "v0.4.0-dev"
+__version__ = "v0.5.0-dev"

--- a/microc_pipeline/cli.py
+++ b/microc_pipeline/cli.py
@@ -1,4 +1,4 @@
-"""CLI for the v0.4.0 config-driven single-sample Micro-C runner."""
+"""CLI for the v0.5.0 config-driven single-sample Micro-C runner."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import argparse
 import sys
 
 from .config import ConfigError, parse_and_validate_config
-from .runner import RunnerError, run_pipeline, validate_chrom_sizes_feasibility
+from .runner import RunnerError, run_pipeline, validate_and_write_manifest, validate_chrom_sizes_feasibility
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -22,6 +22,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     validate_parser = subparsers.add_parser("validate-config", help="Validate a single-sample YAML config.")
     validate_parser.add_argument("--config", required=True, help="YAML config file to validate.")
+
+    validate_outputs_parser = subparsers.add_parser(
+        "validate-outputs",
+        help="Validate standardized final outputs for a completed single-sample run.",
+    )
+    validate_outputs_parser.add_argument("--config", required=True, help="YAML config file for the completed run.")
     return parser
 
 
@@ -34,12 +40,20 @@ def command_validate_config(args: argparse.Namespace) -> int:
     return 0
 
 
+def command_validate_outputs(args: argparse.Namespace) -> int:
+    config = parse_and_validate_config(args.config, check_files=False)
+    validate_and_write_manifest(config)
+    print(f"Output validation succeeded for sample: {config.sample}")
+    print(f"Manifest: {config.sample_output_dir / 'output_manifest.json'}")
+    return 0
+
+
 def command_run(args: argparse.Namespace) -> int:
     config = parse_and_validate_config(args.config, check_files=True)
     validate_chrom_sizes_feasibility(config)
     run_pipeline(config, dry_run=args.dry_run)
     if not args.dry_run:
-        print(f"Run completed for sample: {config.sample}")
+        print(f"Run completed and outputs validated for sample: {config.sample}")
     return 0
 
 
@@ -49,6 +63,8 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if args.command == "validate-config":
             return command_validate_config(args)
+        if args.command == "validate-outputs":
+            return command_validate_outputs(args)
         if args.command == "run":
             return command_run(args)
         parser.error(f"Unknown command: {args.command}")

--- a/microc_pipeline/config.py
+++ b/microc_pipeline/config.py
@@ -1,4 +1,4 @@
-"""Configuration loading and validation for the v0.4.0 single-sample runner."""
+"""Configuration loading and validation for the v0.5.0 single-sample runner."""
 
 from __future__ import annotations
 
@@ -81,7 +81,7 @@ def _parse_scalar(value: str) -> Any:
 
 
 def _parse_simple_yaml(text: str) -> dict[str, Any]:
-    """Parse the small YAML subset used by the documented v0.4.0 config.
+    """Parse the small YAML subset used by the documented v0.5.0 config.
 
     This intentionally supports mappings, nested mappings, scalar values, and
     lists of scalar values so the runner does not need an external Python YAML
@@ -203,7 +203,7 @@ def parse_and_validate_config(
     sample = _require_string(_get_required(raw, "sample"), "sample")
     assay = _require_string(_get_optional(raw, "assay", "microc"), "assay")
     if assay != "microc":
-        raise ConfigError(f"Unsupported assay: {assay}. v0.4.0 supports only assay: microc.")
+        raise ConfigError(f"Unsupported assay: {assay}. v0.5.0 supports only assay: microc.")
 
     fastq_r1 = _resolve_path(_get_required(raw, "fastq.r1"), "fastq.r1")
     fastq_r2 = _resolve_path(_get_required(raw, "fastq.r2"), "fastq.r2")

--- a/microc_pipeline/outputs.py
+++ b/microc_pipeline/outputs.py
@@ -1,0 +1,147 @@
+"""Standardized v0.5.0 output paths and manifest helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from . import __version__
+from .config import PipelineConfig
+
+HIC_FORMAT_NOTE = "Juicer .hic contact-map file format; not enzyme-aware Hi-C assay mode."
+
+
+@dataclass(frozen=True)
+class FinalOutputs:
+    """Standardized final output paths for a single configured sample."""
+
+    sample_dir: Path
+    valid_pairs: Path
+    valid_pairs_index: Path
+    cool: Path
+    mcool: Path
+    hic: Path
+    pairtools_stats: Path
+    preseq: Path
+    qc_tsv: Path
+    bam: Path
+    bam_index: Path
+    output_manifest: Path
+    run_metadata: Path
+
+    @property
+    def valid_pairs_uncompressed(self) -> Path:
+        return self.valid_pairs.with_suffix("")
+
+
+def final_outputs(config: PipelineConfig) -> FinalOutputs:
+    """Return standardized final output paths for *config*."""
+
+    sample = config.sample
+    sample_dir = config.sample_output_dir
+    return FinalOutputs(
+        sample_dir=sample_dir,
+        valid_pairs=sample_dir / "pairs" / f"{sample}.valid.pairs.gz",
+        valid_pairs_index=sample_dir / "pairs" / f"{sample}.valid.pairs.gz.px2",
+        cool=sample_dir / "cool" / f"{sample}.cool",
+        mcool=sample_dir / "cool" / f"{sample}.mcool",
+        hic=sample_dir / "hic" / f"{sample}.hic",
+        pairtools_stats=sample_dir / "stats" / f"{sample}.pairtools.stats.txt",
+        preseq=sample_dir / "stats" / f"{sample}.preseq.lc_extrap.txt",
+        qc_tsv=sample_dir / "qc" / f"{sample}.qc.tsv",
+        bam=sample_dir / "bam" / f"{sample}.PT.bam",
+        bam_index=sample_dir / "bam" / f"{sample}.PT.bam.bai",
+        output_manifest=sample_dir / "output_manifest.json",
+        run_metadata=sample_dir / "run_metadata.json",
+    )
+
+
+def final_output_paths(config: PipelineConfig) -> dict[str, str]:
+    """Return the run_metadata final_outputs mapping for expected outputs."""
+
+    outputs = final_outputs(config)
+    paths = {
+        "valid_pairs": str(outputs.valid_pairs),
+        "valid_pairs_index": str(outputs.valid_pairs_index),
+        "cool": str(outputs.cool),
+        "pairtools_stats": str(outputs.pairtools_stats),
+        "preseq": str(outputs.preseq),
+        "qc_tsv": str(outputs.qc_tsv),
+        "output_manifest": str(outputs.output_manifest),
+    }
+    if config.outputs.make_mcool:
+        paths["mcool"] = str(outputs.mcool)
+    if config.outputs.make_hic:
+        paths["hic"] = str(outputs.hic)
+    if config.outputs.keep_bam:
+        paths["bam"] = str(outputs.bam)
+        paths["bam_index"] = str(outputs.bam_index)
+    return paths
+
+
+def expected_output_entries(config: PipelineConfig) -> dict[str, dict[str, Any]]:
+    """Return manifest output entries expected for *config*."""
+
+    outputs = final_outputs(config)
+    entries: dict[str, dict[str, Any]] = {
+        "valid_pairs": {
+            "path": str(outputs.valid_pairs),
+            "index": str(outputs.valid_pairs_index),
+            "required": True,
+        },
+        "cool": {"path": str(outputs.cool), "required": True},
+        "pairtools_stats": {"path": str(outputs.pairtools_stats), "required": True},
+        "preseq": {"path": str(outputs.preseq), "required": True},
+        "qc_tsv": {"path": str(outputs.qc_tsv), "required": True},
+    }
+    if config.outputs.make_mcool:
+        entries["mcool"] = {"path": str(outputs.mcool), "required": True}
+    else:
+        entries["mcool"] = {"path": str(outputs.mcool), "required": False, "expected": False}
+    if config.outputs.make_hic:
+        entries["hic"] = {
+            "path": str(outputs.hic),
+            "required": True,
+            "note": HIC_FORMAT_NOTE,
+        }
+    else:
+        entries["hic"] = {
+            "path": str(outputs.hic),
+            "required": False,
+            "expected": False,
+            "note": HIC_FORMAT_NOTE,
+        }
+    if config.outputs.keep_bam:
+        entries["bam"] = {
+            "path": str(outputs.bam),
+            "index": str(outputs.bam_index),
+            "required": True,
+        }
+    else:
+        entries["bam"] = {
+            "path": str(outputs.bam),
+            "index": str(outputs.bam_index),
+            "required": False,
+            "expected": False,
+        }
+    return entries
+
+
+def build_manifest(config: PipelineConfig, validation: dict[str, dict[str, Any]] | None = None) -> dict[str, Any]:
+    """Build an output manifest, optionally merging validation results."""
+
+    entries = expected_output_entries(config)
+    validation = validation or {}
+    for name, result in validation.items():
+        if name in entries:
+            entries[name].update(result)
+    for entry in entries.values():
+        entry.setdefault("validated", False)
+    return {
+        "sample": config.sample,
+        "assay": config.assay,
+        "output_dir": str(config.sample_output_dir),
+        "pipeline_version": __version__,
+        "outputs": entries,
+    }

--- a/microc_pipeline/runner.py
+++ b/microc_pipeline/runner.py
@@ -1,4 +1,4 @@
-"""Command construction and execution for the v0.4.0 single-sample workflow."""
+"""Command construction and execution for the v0.5.0 single-sample workflow."""
 
 from __future__ import annotations
 
@@ -12,6 +12,8 @@ from shlex import quote
 
 from . import __version__
 from .config import ConfigError, PipelineConfig
+from .outputs import build_manifest, final_output_paths, final_outputs
+from .validation import OutputValidationError, validate_outputs, validation_checks
 
 OUTPUT_SUBDIRS = ("bam", "cool", "fastqc", "hic", "genome", "logs", "pairs", "qc", "stats", "temp")
 REQUIRED_COMMANDS = (
@@ -123,6 +125,7 @@ def build_metadata(config: PipelineConfig, chrom_sizes: Path, commands: list[str
             "make_hic": config.outputs.make_hic,
             "make_mcool": config.outputs.make_mcool,
         },
+        "final_outputs": final_output_paths(config),
         "pipeline_version": __version__,
         "dry_run": dry_run,
         "created_at": datetime.now(timezone.utc).isoformat(),
@@ -150,9 +153,10 @@ def workflow_commands(config: PipelineConfig, dirs: dict[str, Path], chrom_sizes
     raw_bam = dirs["bam"] / f"{sample}.bam"
     final_bam = dirs["bam"] / f"{sample}.PT.bam"
     final_bai = Path(str(final_bam) + ".bai")
-    pairs = dirs["pairs"] / f"{sample}.pairs"
-    pairs_gz = Path(str(pairs) + ".gz")
-    cool = dirs["cool"] / f"{sample}.cool"
+    outputs = final_outputs(config)
+    pairs = outputs.valid_pairs_uncompressed
+    pairs_gz = outputs.valid_pairs
+    cool = outputs.cool
 
     commands = [
         f"mkdir -p {q(trim_dir)} {q(sample_temp)}",
@@ -166,11 +170,11 @@ def workflow_commands(config: PipelineConfig, dirs: dict[str, Path], chrom_sizes
         f"samtools sort -@ {threads} -T {q(undedup_bam)} -o {q(undedup_pt_bam)} {q(undedup_bam)}",
         f"rm {q(undedup_bam)}",
         f"samtools index {q(undedup_pt_bam)}",
-        f"preseq lc_extrap -bam -pe -extrap 2.1e9 -step 1e8 -seg_len 1000000000 -output {q(dirs['stats'] / ('comp_' + sample + '.txt'))} {q(undedup_pt_bam)}",
+        f"preseq lc_extrap -bam -pe -extrap 2.1e9 -step 1e8 -seg_len 1000000000 -output {q(outputs.preseq)} {q(undedup_pt_bam)}",
         f"rm {q(undedup_pt_bam)}",
-        f"pairtools dedup --nproc-in {threads} --nproc-out {threads} --mark-dups --output-stats {q(dirs['stats'] / (sample + '.txt'))} --output {q(dedup_pairsam)} {q(sorted_pairsam)}",
+        f"pairtools dedup --nproc-in {threads} --nproc-out {threads} --mark-dups --output-stats {q(outputs.pairtools_stats)} --output {q(dedup_pairsam)} {q(sorted_pairsam)}",
         f"rm {q(sorted_pairsam)}",
-        f"python3 {q(get_qc)} -p {q(dirs['stats'] / (sample + '.txt'))} > {q(dirs['qc'] / ('qc_' + sample + '.txt'))}",
+        f"python3 {q(get_qc)} -p {q(outputs.pairtools_stats)} --format tsv > {q(outputs.qc_tsv)}",
         f"pairtools split --nproc-in {threads} --nproc-out {threads} --output-pairs {q(pairs)} --output-sam {q(raw_bam)} {q(dedup_pairsam)}",
         f"rm {q(dedup_pairsam)}",
         f"samtools sort -@ {threads} -T {q(raw_bam)} -o {q(final_bam)} {q(raw_bam)}",
@@ -178,7 +182,7 @@ def workflow_commands(config: PipelineConfig, dirs: dict[str, Path], chrom_sizes
         f"samtools index {q(final_bam)}",
     ]
     if config.outputs.make_hic:
-        commands.append(f"juicer_tools pre -j {threads} {q(pairs)} {q(dirs['hic'] / (sample + '.hic'))} {q(config.genome.name)}")
+        commands.append(f"juicer_tools pre -j {threads} {q(pairs)} {q(outputs.hic)} {q(config.genome.name)}")
     commands.extend(
         [
             f"bgzip {q(pairs)}",
@@ -187,7 +191,7 @@ def workflow_commands(config: PipelineConfig, dirs: dict[str, Path], chrom_sizes
         ]
     )
     if config.outputs.make_mcool:
-        commands.append(f"cooler zoomify -p {threads} {q(cool)}")
+        commands.append(f"cooler zoomify -p {threads} -o {q(outputs.mcool)} {q(cool)}")
     if not config.outputs.keep_bam:
         commands.append(f"rm -f {q(final_bam)} {q(final_bai)}")
     return commands
@@ -208,12 +212,36 @@ def print_plan(config: PipelineConfig, chrom_commands: list[str], commands: list
     print(f"Threads: {config.threads}")
     if len(config.bin_sizes) > 1:
         print(
-            "Warning: v0.4.0 uses only the first configured bin size for .cool generation: "
+            "Warning: v0.5.0 uses only the first configured bin size for .cool generation: "
             f"{config.bin_sizes[0]}"
         )
     print("Planned commands:")
     for command in [*chrom_commands, *commands]:
         print(command)
+    print("Expected final outputs:")
+    for name, path in final_output_paths(config).items():
+        print(f"{name}: {path}")
+    print("Planned validation checks:")
+    for check in validation_checks(config):
+        print(f"- {check}")
+
+
+def write_output_manifest(config: PipelineConfig, validation_results: dict[str, dict[str, object]] | None = None) -> None:
+    manifest_path = final_outputs(config).output_manifest
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(build_manifest(config, validation_results), indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def validate_and_write_manifest(config: PipelineConfig) -> None:
+    try:
+        results = validate_outputs(config)
+    except OutputValidationError as exc:
+        write_output_manifest(config, exc.results)
+        raise RunnerError(str(exc)) from exc
+    write_output_manifest(config, results)
 
 
 def run_pipeline(config: PipelineConfig, *, dry_run: bool = False) -> None:
@@ -232,7 +260,7 @@ def run_pipeline(config: PipelineConfig, *, dry_run: bool = False) -> None:
         return
 
     metadata = build_metadata(config, chrom_sizes, all_commands, dry_run=False)
-    metadata_path = config.sample_output_dir / "run_metadata.json"
+    metadata_path = final_outputs(config).run_metadata
     metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
 
     log_path = dirs["logs"] / f"{config.sample}.log"
@@ -244,7 +272,7 @@ def run_pipeline(config: PipelineConfig, *, dry_run: bool = False) -> None:
         print(f"Threads: {config.threads}", file=log_handle)
         if len(config.bin_sizes) > 1:
             print(
-                "Warning: v0.4.0 uses only the first configured bin size for .cool generation: "
+                "Warning: v0.5.0 uses only the first configured bin size for .cool generation: "
                 f"{config.bin_sizes[0]}",
                 file=log_handle,
             )
@@ -252,6 +280,8 @@ def run_pipeline(config: PipelineConfig, *, dry_run: bool = False) -> None:
             print(f"$ {command}", file=log_handle, flush=True)
         for command in commands:
             run_shell(command, log_handle=log_handle)
+
+    validate_and_write_manifest(config)
 
 
 def validate_chrom_sizes_feasibility(config: PipelineConfig) -> None:

--- a/microc_pipeline/validation.py
+++ b/microc_pipeline/validation.py
@@ -1,0 +1,129 @@
+"""Lightweight validation for standardized v0.5.0 final outputs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .config import PipelineConfig
+from .outputs import expected_output_entries
+
+PAIRTOOLS_STATS_REQUIRED_KEYS = (
+    "total",
+    "total_unmapped",
+    "total_mapped",
+    "total_dups",
+    "total_nodups",
+    "cis",
+    "trans",
+    "cis_1kb+",
+    "cis_10kb+",
+)
+
+QC_TSV_REQUIRED_COLUMNS = ("metric", "value", "percent")
+
+
+class OutputValidationError(RuntimeError):
+    """Raised when one or more expected final outputs are missing or invalid."""
+
+    def __init__(self, failures: list[str], results: dict[str, dict[str, Any]]):
+        self.failures = failures
+        self.results = results
+        super().__init__("Output validation failed:\n" + "\n".join(f"- {failure}" for failure in failures))
+
+
+def _file_status(path: Path) -> tuple[bool, int]:
+    if not path.is_file():
+        return False, 0
+    return True, path.stat().st_size
+
+
+def _check_nonempty(path: Path, label: str, failures: list[str]) -> dict[str, Any]:
+    exists, size = _file_status(path)
+    if not exists:
+        failures.append(f"{label} is missing: {path}")
+    elif size <= 0:
+        failures.append(f"{label} is empty: {path}")
+    return {"exists": exists, "size_bytes": size}
+
+
+def _read_stats_keys(path: Path) -> set[str]:
+    keys: set[str] = set()
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            fields = line.split()
+            if len(fields) >= 2:
+                keys.add(fields[0])
+    return keys
+
+
+def validation_checks(config: PipelineConfig) -> list[str]:
+    """Describe planned validation checks for dry-run output."""
+
+    entries = expected_output_entries(config)
+    checks = [
+        "valid_pairs: non-empty .valid.pairs.gz and non-empty .px2 pairix index",
+        "cool: non-empty .cool file",
+        "pairtools_stats: non-empty stats file with required get_qc.py keys",
+        "preseq: non-empty lc_extrap output",
+        "qc_tsv: non-empty TSV with metric/value/percent header columns",
+    ]
+    if entries["mcool"].get("required"):
+        checks.append("mcool: non-empty .mcool file")
+    if entries["hic"].get("required"):
+        checks.append("hic: non-empty Juicer .hic contact-map file")
+    if entries["bam"].get("required"):
+        checks.append("bam: non-empty final BAM and BAI files")
+    return checks
+
+
+def validate_outputs(config: PipelineConfig) -> dict[str, dict[str, Any]]:
+    """Validate expected final outputs for *config*.
+
+    Returns per-output validation metadata. Raises OutputValidationError when a
+    required output is missing or invalid.
+    """
+
+    entries = expected_output_entries(config)
+    failures: list[str] = []
+    results: dict[str, dict[str, Any]] = {}
+
+    for name, entry in entries.items():
+        if not entry.get("required", False):
+            results[name] = {"validated": True, "skipped": True, "reason": "not expected by config"}
+            continue
+
+        output_failures: list[str] = []
+        path = Path(entry["path"])
+        result: dict[str, Any] = {"checks": {}}
+        result["checks"]["path"] = _check_nonempty(path, name, output_failures)
+
+        if "index" in entry:
+            result["checks"]["index"] = _check_nonempty(Path(entry["index"]), f"{name} index", output_failures)
+
+        if name == "pairtools_stats" and path.is_file() and path.stat().st_size > 0:
+            keys = _read_stats_keys(path)
+            missing = [key for key in PAIRTOOLS_STATS_REQUIRED_KEYS if key not in keys]
+            result["required_keys"] = list(PAIRTOOLS_STATS_REQUIRED_KEYS)
+            if missing:
+                output_failures.append(
+                    "pairtools_stats is missing required key(s): " + ", ".join(missing)
+                )
+
+        if name == "qc_tsv" and path.is_file() and path.stat().st_size > 0:
+            with open(path, "r", encoding="utf-8") as handle:
+                header = handle.readline().rstrip("\n").split("\t")
+            result["header"] = header
+            missing_columns = [column for column in QC_TSV_REQUIRED_COLUMNS if column not in header]
+            if missing_columns:
+                output_failures.append("qc_tsv header missing column(s): " + ", ".join(missing_columns))
+
+        result["validated"] = not output_failures
+        if output_failures:
+            result["errors"] = output_failures
+            failures.extend(output_failures)
+        results[name] = result
+
+    if failures:
+        raise OutputValidationError(failures, results)
+    return results


### PR DESCRIPTION
### Motivation
- Standardize final output paths (valid pairs, matrices, stats, QC, optional `.hic`/BAM) so downstream tools and users can rely on stable, config-driven filenames.
- Treat valid pairs and matrix products as first-class validated artifacts and expose lightweight validation for completed runs.
- Provide a machine-readable `output_manifest.json` recording expected outputs and validation status to support inspection without rerunning preprocessing.
- Preserve legacy behavior while adding a TSV QC mode for programmatic QC consumption and improve documentation for v0.5.0 output semantics.

### Description
- Added standardized output helpers in `microc_pipeline/outputs.py` and lightweight validators in `microc_pipeline/validation.py`, plus manifest building with `output_manifest.json` support.
- Updated the runner (`microc_pipeline/runner.py`) to emit the new standardized file paths, include `final_outputs` in `run_metadata.json`, write the manifest after validation, and expose `validate_and_write_manifest`/`validate-outputs` behavior.
- Extended the CLI (`microc_pipeline/cli.py`) with a `validate-outputs` command, bumped package version to `v0.5.0-dev`, and updated `get_qc.py` to support `--format tsv` while keeping legacy text output.
- Updated docs, README, and `CHANGELOG.md` to document the v0.5.0 output layout, validation checks, manifest schema, and boundaries (including `.hic` format note and Micro-C-first behavior).

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a266e61a5b083278bbcd0efec7d236f)