### PR TITLE
v0.5.1: Add preflight and reproducibility hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.5.1 - Unreleased
+
+### Added
+- Added sample name validation for the config-driven runner.
+- Added BWA index preflight validation for non-empty `.amb`, `.ann`, `.bwt`, `.pac`, and `.sa` sidecar files.
+- Added best-effort command-line tool version collection to `run_metadata.json`.
+
+### Changed
+- Removed an unreachable FASTA directory guard and cleaned up minor import placement.
+- Updated documentation for v0.5.1 preflight and reproducibility behavior.
+
+### Notes
+- This hardening release does not add restartable chunking, multi-sample support, full QC reports, or changes to the core processing command sequence.
+
 ## v0.5.0 - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # microC-pipeline
 
-`microC-pipeline` is a Micro-C preprocessing repository. The v0.5.0 development milestone keeps the lightweight config-driven single-sample runner introduced in v0.4.0 and makes its valid pairs, matrix, stats, QC, and manifest files first-class validated products.
+`microC-pipeline` is a Micro-C preprocessing repository. The v0.5.1 development milestone keeps the v0.5.0 output behavior and adds lightweight preflight and reproducibility hardening to the config-driven single-sample runner.
 
 The preferred interface is:
 
@@ -40,7 +40,7 @@ The default workflow is Micro-C-oriented. No restriction enzyme is required, the
 
 ```text
 README.md                         Project overview and usage notes
-bin/microc-pipeline               v0.5.0 config-driven single-sample CLI
+bin/microc-pipeline               v0.5.1 config-driven single-sample CLI
 microc_pipeline/                  Python package for config, output paths, validation, and command execution
 config/example.single-sample.yaml Example single-sample Micro-C config
 config/README.md                  Configuration directory notes
@@ -58,7 +58,7 @@ examples/README.md                Placeholder for future tiny synthetic examples
 
 ## Config-driven usage
 
-Start from `config/example.single-sample.yaml`:
+Start from `config/example.single-sample.yaml`; `sample` must match `^[A-Za-z0-9][A-Za-z0-9._-]*$`:
 
 ```yaml
 sample: SAMPLE_ID
@@ -98,7 +98,7 @@ Run one sample:
 bin/microc-pipeline run --config config/example.single-sample.yaml
 ```
 
-Validate outputs from an existing completed run without rerunning preprocessing:
+Validate outputs from an existing completed run without rerunning preprocessing. This command does not require original FASTQs or genome FASTA resources to still exist:
 
 ```bash
 bin/microc-pipeline validate-outputs --config config/example.single-sample.yaml
@@ -126,7 +126,7 @@ results/SAMPLE/
   output_manifest.json
 ```
 
-`run_metadata.json` records how the run was configured and executed, including standardized final output paths. `output_manifest.json` records which final outputs were expected and whether validation passed. Detailed output semantics, validation checks, and manifest fields are documented in `docs/outputs.md`.
+`run_metadata.json` records how the run was configured and executed, including standardized final output paths and best-effort external `tool_versions` for real runs. `output_manifest.json` records which final outputs were expected and whether validation passed. Detailed output semantics, validation checks, and manifest fields are documented in `docs/outputs.md`.
 
 ## Requirements
 
@@ -145,7 +145,7 @@ Install and configure dependencies before launching a real run. The config-drive
 
 The runner checks `juicer_tools` only when `outputs.make_hic: true`.
 
-The required genome FASTA should already have BWA indexes available for alignment. If `genome.chrom_sizes` is not provided, `genome.fasta` should have an existing non-empty `.fai` index, or the FASTA directory must be writable so the runner can create the index with `samtools faidx`.
+The required genome FASTA must already have non-empty BWA index sidecars (`.amb`, `.ann`, `.bwt`, `.pac`, and `.sa`) before `validate-config` or `run` can proceed. If `genome.chrom_sizes` is not provided, `genome.fasta` should also have an existing non-empty `.fai` index, or the FASTA directory must be writable so the runner can create the index with `samtools faidx`.
 
 ### HPC modules are site-specific
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ Validate configuration without running preprocessing:
 bin/microc-pipeline validate-config --config config/example.single-sample.yaml
 ```
 
-Validate outputs from an existing completed run. This command uses the config only to infer expected output paths and toggles, so it does not require the original FASTQs or genome FASTA to still be present:
+Validate outputs from an existing completed run. This command uses the config only to infer expected output paths and toggles, so it does not require the original FASTQs, genome FASTA, or BWA index sidecars to still be present:
 
 ```bash
 bin/microc-pipeline validate-outputs --config config/example.single-sample.yaml
@@ -44,12 +44,12 @@ outputs:
 
 | Field | Required | Default | Description |
 | --- | --- | --- | --- |
-| `sample` | Yes | None | Sample identifier used in the per-sample output directory and standardized output names. |
+| `sample` | Yes | None | Sample identifier used in the per-sample output directory and standardized output names. Must match `^[A-Za-z0-9][A-Za-z0-9._-]*$`. |
 | `assay` | No | `microc` | Only `microc` is supported. No enzyme-aware Hi-C mode is implemented. |
 | `fastq.r1` | Yes | None | R1 FASTQ path. |
 | `fastq.r2` | Yes | None | R2 FASTQ path. |
 | `genome.name` | Yes | None | Genome label passed to tools that need a genome name. |
-| `genome.fasta` | Yes | None | Reference FASTA path. BWA indexes should already exist. |
+| `genome.fasta` | Yes | None | Reference FASTA path. Non-empty BWA index sidecars (`.amb`, `.ann`, `.bwt`, `.pac`, `.sa`) must already exist before `validate-config` or `run`. |
 | `genome.chrom_sizes` | No | `null` | Optional chromosome sizes file. If omitted, the runner uses `genome.fasta.fai` or creates it with `samtools faidx` when the FASTA directory is writable. |
 | `threads` | No | `$SLURM_CPUS_PER_TASK` or `16` | Positive integer thread count. |
 | `bin_sizes` | No | `[1000]` | Positive integer bin sizes. v0.5.0 uses the first value for `.cool`; optional `.mcool` is produced by `cooler zoomify`. |
@@ -69,11 +69,11 @@ The output toggles define both the commands that are planned and the final files
 - `outputs.make_mcool: true` makes `cool/SAMPLE.mcool` a required validated output.
 - `outputs.make_mcool: false` skips `.mcool` creation and validation.
 
-Always-required final outputs are the BGZF-compressed valid pairs file, Pairix index, `.cool`, Pairtools stats, Preseq output, QC TSV, `run_metadata.json`, and `output_manifest.json`.
+Always-required final outputs are the BGZF-compressed valid pairs file, Pairix index, `.cool`, Pairtools stats, Preseq output, QC TSV, `run_metadata.json`, and `output_manifest.json`. For real runs, `run_metadata.json` includes best-effort `tool_versions` records for required command-line tools.
 
 ## Dry run
 
-Dry-run mode prints planned commands, expected final outputs, and planned validation checks without validating files:
+Dry-run mode validates the config and BWA index preflight, then prints planned commands, expected final outputs, and planned validation checks without running external tools:
 
 ```bash
 bin/microc-pipeline run --config config/example.single-sample.yaml --dry-run

--- a/docs/design.md
+++ b/docs/design.md
@@ -7,7 +7,7 @@
 1. A retained legacy Slurm script, `mdp.sh`, kept for backward compatibility.
 2. A lightweight config-driven single-sample runner, `bin/microc-pipeline`, for modernized Micro-C preprocessing.
 
-The v0.5.0 milestone keeps the v0.4.0 single-sample runner model and makes final valid pairs, matrix, stats, QC, and manifest files first-class products. It adds standardized names, output validation, `output_manifest.json`, and a `validate-outputs` command.
+The v0.5.0 milestone keeps the v0.4.0 single-sample runner model and makes final valid pairs, matrix, stats, QC, and manifest files first-class products. The v0.5.1 hardening milestone preserves that output behavior while adding safe sample-name validation, BWA index preflight checks for `validate-config` and `run`, and best-effort tool-version metadata for real runs.
 
 ## Micro-C-first boundary
 
@@ -41,9 +41,9 @@ These remain future milestones.
 
 ## Metadata and manifest split
 
-`run_metadata.json` records how a run was configured and executed: config path, inputs, genome resources, threads, commands, output toggles, and standardized final output paths.
+`run_metadata.json` records how a run was configured and executed: config path, inputs, genome resources, threads, commands, output toggles, standardized final output paths, and best-effort command-line tool versions.
 
-`output_manifest.json` records what final outputs were expected and whether lightweight validation passed. Keeping these concerns separate makes output inspection possible without treating execution provenance as validation state.
+`output_manifest.json` records what final outputs were expected and whether lightweight validation passed. Keeping these concerns separate makes output inspection possible without treating execution provenance as validation state; `validate-outputs` intentionally does not require original FASTQs or genome FASTA resources.
 
 ## Future direction
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -231,6 +231,23 @@ Expected status after this milestone:
 The pipeline has clear, validated, documented final outputs.
 ```
 
+## Milestone v0.5.1: preflight and reproducibility hardening
+
+Goal: harden the existing single-sample runner without changing v0.5.0 output names or the core command sequence.
+
+Planned or completed tasks:
+
+- [x] Validate safe config `sample` names with `^[A-Za-z0-9][A-Za-z0-9._-]*$`.
+- [x] Require non-empty BWA index sidecars before `validate-config` and `run`.
+- [x] Record best-effort external command `tool_versions` in `run_metadata.json` for real runs.
+- [x] Keep `validate-outputs` independent of original FASTQs and genome resources.
+
+Expected status after this milestone:
+
+```text
+The v0.5.0 output contract remains unchanged while preflight errors and run provenance improve.
+```
+
 ## Milestone v0.6.0: restartable chunk engine
 
 Goal: integrate the restartability concepts developed in HiC-Nap.

--- a/microc_pipeline/__init__.py
+++ b/microc_pipeline/__init__.py
@@ -1,3 +1,3 @@
 """Lightweight config-driven Micro-C preprocessing entrypoint."""
 
-__version__ = "v0.5.0-dev"
+__version__ = "v0.5.1-dev"

--- a/microc_pipeline/cli.py
+++ b/microc_pipeline/cli.py
@@ -6,7 +6,13 @@ import argparse
 import sys
 
 from .config import ConfigError, parse_and_validate_config
-from .runner import RunnerError, run_pipeline, validate_and_write_manifest, validate_chrom_sizes_feasibility
+from .runner import (
+    RunnerError,
+    run_pipeline,
+    validate_and_write_manifest,
+    validate_bwa_index,
+    validate_chrom_sizes_feasibility,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -33,6 +39,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def command_validate_config(args: argparse.Namespace) -> int:
     config = parse_and_validate_config(args.config, check_files=True)
+    validate_bwa_index(config)
     validate_chrom_sizes_feasibility(config)
     print(f"Config validation succeeded for sample: {config.sample}")
     print(f"Assay: {config.assay}")
@@ -50,6 +57,7 @@ def command_validate_outputs(args: argparse.Namespace) -> int:
 
 def command_run(args: argparse.Namespace) -> int:
     config = parse_and_validate_config(args.config, check_files=True)
+    validate_bwa_index(config)
     validate_chrom_sizes_feasibility(config)
     run_pipeline(config, dry_run=args.dry_run)
     if not args.dry_run:

--- a/microc_pipeline/config.py
+++ b/microc_pipeline/config.py
@@ -1,8 +1,9 @@
-"""Configuration loading and validation for the v0.5.0 single-sample runner."""
+"""Configuration loading and validation for the v0.5.1 single-sample runner."""
 
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -43,6 +44,7 @@ class PipelineConfig:
 
 
 _MISSING = object()
+_SAFE_SAMPLE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
 def _strip_comment(line: str) -> str:
@@ -178,6 +180,15 @@ def _require_string(value: Any, field: str) -> str:
     return value
 
 
+def _validate_sample_name(sample: str) -> None:
+    if not _SAFE_SAMPLE_RE.fullmatch(sample):
+        raise ConfigError(
+            "Invalid config field sample: expected a safe sample name matching "
+            r"^[A-Za-z0-9][A-Za-z0-9._-]*$ "
+            "(start with a letter or digit; use only letters, digits, dot, underscore, or hyphen)."
+        )
+
+
 def _require_bool(value: Any, field: str) -> bool:
     if not isinstance(value, bool):
         raise ConfigError(f"Invalid config field {field}: expected true or false.")
@@ -201,6 +212,7 @@ def parse_and_validate_config(
         raise ConfigError("Config root must be a mapping.")
 
     sample = _require_string(_get_required(raw, "sample"), "sample")
+    _validate_sample_name(sample)
     assay = _require_string(_get_optional(raw, "assay", "microc"), "assay")
     if assay != "microc":
         raise ConfigError(f"Unsupported assay: {assay}. v0.5.0 supports only assay: microc.")

--- a/microc_pipeline/runner.py
+++ b/microc_pipeline/runner.py
@@ -1,8 +1,9 @@
-"""Command construction and execution for the v0.5.0 single-sample workflow."""
+"""Command construction and execution for the v0.5.1 single-sample workflow."""
 
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -28,6 +29,20 @@ REQUIRED_COMMANDS = (
     "cooler",
     "python3",
 )
+BWA_INDEX_SUFFIXES = (".amb", ".ann", ".bwt", ".pac", ".sa")
+VERSION_COMMANDS = {
+    "fastqc": "fastqc --version",
+    "trim_galore": "trim_galore --version",
+    "samtools": "samtools --version",
+    "bwa": "bwa 2>&1",
+    "pairtools": "pairtools --version",
+    "preseq": "preseq --version",
+    "bgzip": "bgzip --version",
+    "pairix": "pairix --version",
+    "cooler": "cooler --version",
+    "python3": "python3 --version",
+    "juicer_tools": "juicer_tools --version",
+}
 
 
 class RunnerError(RuntimeError):
@@ -47,13 +62,70 @@ def trim_galore_output_name(fastq: Path, read_number: int) -> str:
     return f"{name}_val_{read_number}.fq.gz"
 
 
-def check_dependencies(config: PipelineConfig) -> None:
+def required_commands_for_config(config: PipelineConfig) -> list[str]:
     required = list(REQUIRED_COMMANDS)
     if config.outputs.make_hic:
         required.append("juicer_tools")
-    missing = [command for command in required if shutil.which(command) is None]
+    return required
+
+
+def check_dependencies(config: PipelineConfig) -> None:
+    missing = [command for command in required_commands_for_config(config) if shutil.which(command) is None]
     if missing:
         raise RunnerError("Missing required command(s): " + ", ".join(missing))
+
+
+def validate_bwa_index(config: PipelineConfig) -> None:
+    invalid = []
+    for suffix in BWA_INDEX_SUFFIXES:
+        sidecar = Path(str(config.genome.fasta) + suffix)
+        if not sidecar.is_file() or sidecar.stat().st_size == 0:
+            invalid.append(sidecar)
+    if invalid:
+        raise ConfigError(
+            f"BWA index files are missing or empty for genome FASTA {config.genome.fasta}. "
+            f"Create them first with: bwa index {q(config.genome.fasta)}"
+        )
+
+
+def collect_tool_versions(config: PipelineConfig) -> dict[str, dict[str, object]]:
+    versions: dict[str, dict[str, object]] = {}
+    for command in required_commands_for_config(config):
+        executable = shutil.which(command)
+        version_command = VERSION_COMMANDS[command]
+        record: dict[str, object] = {
+            "path": executable,
+            "available": executable is not None,
+            "version": None,
+            "version_command": version_command,
+            "version_exit_code": None,
+        }
+        if executable is None:
+            record["error"] = "command not found"
+            versions[command] = record
+            continue
+        try:
+            completed = subprocess.run(
+                version_command,
+                shell=True,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=15,
+            )
+        except Exception as exc:  # best-effort provenance only
+            record["error"] = str(exc)
+            versions[command] = record
+            continue
+        output = completed.stdout.strip()
+        record["version_exit_code"] = completed.returncode
+        if completed.returncode == 0 and output:
+            record["version"] = output.splitlines()[0]
+        else:
+            record["error"] = output or f"version command exited with {completed.returncode}"
+        versions[command] = record
+    return versions
 
 
 def ensure_output_dirs(config: PipelineConfig) -> dict[str, Path]:
@@ -81,8 +153,6 @@ def derive_chrom_sizes(config: PipelineConfig, dirs: dict[str, Path], *, dry_run
             raise RunnerError(f"FASTA directory does not exist: {fasta_dir}")
         if not dry_run and not fasta_dir.is_dir():
             raise RunnerError(f"FASTA directory is not a directory: {fasta_dir}")
-        if not dry_run and not fasta_dir.stat().st_mode:
-            raise RunnerError(f"Cannot inspect FASTA directory: {fasta_dir}")
         if dry_run or os_access_writable(fasta_dir):
             commands.append(f"samtools faidx {q(config.genome.fasta)}")
             if not dry_run:
@@ -102,12 +172,17 @@ def derive_chrom_sizes(config: PipelineConfig, dirs: dict[str, Path], *, dry_run
 
 
 def os_access_writable(path: Path) -> bool:
-    import os
-
     return os.access(path, os.W_OK)
 
 
-def build_metadata(config: PipelineConfig, chrom_sizes: Path, commands: list[str], *, dry_run: bool) -> dict[str, object]:
+def build_metadata(
+    config: PipelineConfig,
+    chrom_sizes: Path,
+    commands: list[str],
+    *,
+    dry_run: bool,
+    tool_versions: dict[str, dict[str, object]] | None = None,
+) -> dict[str, object]:
     return {
         "sample": config.sample,
         "assay": config.assay,
@@ -127,6 +202,7 @@ def build_metadata(config: PipelineConfig, chrom_sizes: Path, commands: list[str
         },
         "final_outputs": final_output_paths(config),
         "pipeline_version": __version__,
+        "tool_versions": tool_versions or {},
         "dry_run": dry_run,
         "created_at": datetime.now(timezone.utc).isoformat(),
         "commands": commands,
@@ -259,7 +335,8 @@ def run_pipeline(config: PipelineConfig, *, dry_run: bool = False) -> None:
         print_plan(config, chrom_commands, commands)
         return
 
-    metadata = build_metadata(config, chrom_sizes, all_commands, dry_run=False)
+    tool_versions = collect_tool_versions(config)
+    metadata = build_metadata(config, chrom_sizes, all_commands, dry_run=False, tool_versions=tool_versions)
     metadata_path = final_outputs(config).run_metadata
     metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
 


### PR DESCRIPTION
### Motivation
- Harden the single-sample runner with quick preflight and provenance checks to reduce confusing runtime failures and improve reproducibility. 
- Validate user-provided sample identifiers to avoid unsafe filesystem or shell interactions. 
- Record best-effort tool version info for real runs to aid debugging and provenance without making runs brittle. 
- Preserve the v0.5.0 output contract and `validate-outputs` behavior while adding minimal, focused fixes and docs.

### Description
- Added safe sample-name validation to `parse_and_validate_config` using the regex `^[A-Za-z0-9][A-Za-z0-9._-]*$` and raise `ConfigError` for invalid names (`microc_pipeline/config.py`).
- Added BWA index sidecar preflight checking for `.amb`, `.ann`, `.bwt`, `.pac`, and `.sa` via `validate_bwa_index` and wired it into `validate-config` and `run` (but not `validate-outputs`) (`microc_pipeline/runner.py`, `microc_pipeline/cli.py`).
- Implemented best-effort `collect_tool_versions` to capture `path`, `available`, `version`, `version_command`, and `version_exit_code` for required tools (conditionally including `juicer_tools`) and record the data in `run_metadata.json` via `build_metadata` (`microc_pipeline/runner.py`).
- Removed an unreachable FASTA directory `st_mode` guard and moved local `import os` usage to module-level where relevant, leaving core commands and outputs unchanged (`microc_pipeline/runner.py`).
- Bumped the package dev version to `v0.5.1-dev` and updated docs and `CHANGELOG.md` with a new `v0.5.1 - Unreleased` section describing the hardening changes, and small README/docs tweaks about `sample`, BWA index preflight, `tool_versions`, and `validate-outputs` semantics (`CHANGELOG.md`, `README.md`, `docs/configuration.md`, `docs/design.md`, `docs/roadmap.md`, `microc_pipeline/__init__.py`).

### Testing
- Ran `bash -n mdp.sh` with no syntax errors and `python3 -m py_compile microc_pipeline/*.py` and `python3 -m py_compile get_qc.py` which all succeeded. 
- Confirmed CLI help commands succeed: `bin/microc-pipeline --help`, `bin/microc-pipeline run --help`, `bin/microc-pipeline validate-config --help`, and `bin/microc-pipeline validate-outputs --help`. 
- Verified invalid sample names cause `validate-config` to fail with a clear message using `sample: bad/sample`. 
- Verified missing/empty BWA index sidecars cause `validate-config` and `run --dry-run` to fail early with the suggested `bwa index <fasta>` instruction. 
- Verified `validate-outputs` still succeeds when original FASTQs or genome FASTA are missing by staging expected final outputs. 
- Ran a unit-style check of `collect_tool_versions` which recorded `python3` as available and omitted `juicer_tools` when `outputs.make_hic: false`; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a268b36a6208327b8a1f4a4b2fc3a5f)