### PR TITLE
Rename CLI to Wulf3C, add `bin/wulf3c` entrypoint and deprecate `bin/microc-pipeline`; update docs and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ All notable changes to this project will be documented in this file.
 - Added best-effort command-line tool version collection to `run_metadata.json`.
 
 ### Changed
+- Renamed the preferred public CLI command from `bin/microc-pipeline` to `bin/wulf3c`; the old command remains as a deprecated compatibility wrapper.
 - Removed an unreachable FASTA directory guard and cleaned up minor import placement.
 - Updated documentation for v0.5.1 preflight and reproducibility behavior.
 
 ### Notes
+- The `assay: microc` configuration value and standardized output contract are unchanged by the Wulf3C command rename.
 - This hardening release does not add restartable chunking, multi-sample support, full QC reports, or changes to the core processing command sequence.
 
 ## v0.5.0 - 2026-06-08

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 The preferred interface is:
 
 ```bash
-bin/microc-pipeline run --config config/example.single-sample.yaml
+bin/wulf3c run --config config/example.single-sample.yaml
 ```
 
 The retained legacy interface remains available for backward compatibility:
@@ -44,7 +44,8 @@ The default workflow is Micro-C-oriented. No restriction enzyme is required, the
 
 ```text
 README.md                         Project overview and usage notes
-bin/microc-pipeline               v0.5.1 config-driven single-sample CLI
+bin/wulf3c                       v0.5.1 config-driven single-sample CLI
+bin/microc-pipeline              Deprecated compatibility wrapper for older command examples
 microc_pipeline/                  Python package for config, output paths, validation, and command execution
 config/example.single-sample.yaml Example single-sample Micro-C config
 config/README.md                  Configuration directory notes
@@ -87,25 +88,25 @@ outputs:
 Validate a config:
 
 ```bash
-bin/microc-pipeline validate-config --config config/example.single-sample.yaml
+bin/wulf3c validate-config --config config/example.single-sample.yaml
 ```
 
 Print planned commands, expected final outputs, and planned validation checks without running external tools:
 
 ```bash
-bin/microc-pipeline run --config config/example.single-sample.yaml --dry-run
+bin/wulf3c run --config config/example.single-sample.yaml --dry-run
 ```
 
 Run one sample:
 
 ```bash
-bin/microc-pipeline run --config config/example.single-sample.yaml
+bin/wulf3c run --config config/example.single-sample.yaml
 ```
 
 Validate outputs from an existing completed run without rerunning preprocessing. This command does not require original FASTQs or genome FASTA resources to still exist:
 
 ```bash
-bin/microc-pipeline validate-outputs --config config/example.single-sample.yaml
+bin/wulf3c validate-outputs --config config/example.single-sample.yaml
 ```
 
 See `docs/configuration.md` for required fields, defaults, dry-run behavior, genome FASTA index handling, output toggles, and current limitations.

--- a/bin/wulf3c
+++ b/bin/wulf3c
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Deprecated compatibility wrapper for the Wulf3C CLI."""
+"""Command-line entrypoint for the Wulf3C runner."""
 
 import sys
 from pathlib import Path

--- a/config/README.md
+++ b/config/README.md
@@ -7,13 +7,13 @@ This directory contains example configuration files for the lightweight config-d
 Validate a config before launching a full run:
 
 ```bash
-bin/microc-pipeline validate-config --config config/example.single-sample.yaml
+bin/wulf3c validate-config --config config/example.single-sample.yaml
 ```
 
 Print the planned command sequence without running external tools:
 
 ```bash
-bin/microc-pipeline run --config config/example.single-sample.yaml --dry-run
+bin/wulf3c run --config config/example.single-sample.yaml --dry-run
 ```
 
 The default v0.4.0 workflow is Micro-C-oriented and does not require restriction enzyme information.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,19 +3,19 @@
 The config-driven runner accepts one YAML file for one Micro-C sample:
 
 ```bash
-bin/microc-pipeline run --config config/example.single-sample.yaml
+bin/wulf3c run --config config/example.single-sample.yaml
 ```
 
 Validate configuration without running preprocessing:
 
 ```bash
-bin/microc-pipeline validate-config --config config/example.single-sample.yaml
+bin/wulf3c validate-config --config config/example.single-sample.yaml
 ```
 
 Validate outputs from an existing completed run. This command uses the config only to infer expected output paths and toggles, so it does not require the original FASTQs, genome FASTA, or BWA index sidecars to still be present:
 
 ```bash
-bin/microc-pipeline validate-outputs --config config/example.single-sample.yaml
+bin/wulf3c validate-outputs --config config/example.single-sample.yaml
 ```
 
 ## Example
@@ -76,7 +76,7 @@ Always-required final outputs are the BGZF-compressed valid pairs file, Pairix i
 Dry-run mode validates the config and BWA index preflight, then prints planned commands, expected final outputs, and planned validation checks without running external tools:
 
 ```bash
-bin/microc-pipeline run --config config/example.single-sample.yaml --dry-run
+bin/wulf3c run --config config/example.single-sample.yaml --dry-run
 ```
 
 Dry-run mode is intended for inspection. It may create no files at all.

--- a/docs/design.md
+++ b/docs/design.md
@@ -2,10 +2,10 @@
 
 ## Current design
 
-`microC-pipeline` currently has two interfaces:
+`Wulf3C` currently has two interfaces:
 
 1. A retained legacy Slurm script, `mdp.sh`, kept for backward compatibility.
-2. A lightweight config-driven single-sample runner, `bin/microc-pipeline`, for modernized Micro-C preprocessing.
+2. A lightweight config-driven single-sample runner, `bin/wulf3c`, for modernized Micro-C preprocessing.
 
 The v0.5.0 milestone keeps the v0.4.0 single-sample runner model and makes final valid pairs, matrix, stats, QC, and manifest files first-class products. The v0.5.1 hardening milestone preserves that output behavior while adding safe sample-name validation, BWA index preflight checks for `validate-config` and `run`, and best-effort tool-version metadata for real runs.
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -7,7 +7,7 @@ This document describes the v0.5.0 standardized output layout for the config-dri
 The v0.5.0 output standardization applies to:
 
 ```bash
-bin/microc-pipeline run --config config/example.single-sample.yaml
+bin/wulf3c run --config config/example.single-sample.yaml
 ```
 
 It does not change the retained legacy `mdp.sh` output layout.
@@ -74,7 +74,7 @@ Examples include trimmed FASTQs, SAM, Pairtools `.pairsam` intermediates, undedu
 A real `run` validates expected final outputs before printing success. The same checks can be run against an existing output directory without rerunning preprocessing:
 
 ```bash
-bin/microc-pipeline validate-outputs --config config/example.single-sample.yaml
+bin/wulf3c validate-outputs --config config/example.single-sample.yaml
 ```
 
 Validation is intentionally lightweight and conservative. It checks file presence, non-empty sizes, and small format indicators needed by this repository. It does not prove biological correctness.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,8 +1,8 @@
-# microC-pipeline roadmap
+# Wulf3C roadmap
 
 This roadmap describes the intended path from the current legacy/minimal Slurm script toward a production-grade Micro-C / Hi-C preprocessing pipeline.
 
-The long-term goal is to make `microC-pipeline` a restartable, reproducible, inspectable workflow that takes paired-end FASTQ files to validated contact files, contact matrices, and QC reports.
+The long-term goal is to make `Wulf3C` a restartable, reproducible, inspectable workflow that takes paired-end FASTQ files to validated contact files, contact matrices, and QC reports.
 
 > Working vision: **A restartable, reproducible Micro-C/Hi-C preprocessing pipeline from FASTQ to contact maps and QC reports.**
 
@@ -61,16 +61,16 @@ The v1.0.0 release should be built around the following principles.
 
 ## Relationship to HiC-Nap
 
-HiC-Nap is currently a separate restartable chunk-based preprocessing prototype. Its design is directly relevant to the future of `microC-pipeline`.
+HiC-Nap is currently a separate restartable chunk-based preprocessing prototype. Its design is directly relevant to the future of `Wulf3C`.
 
 Planned direction:
 
 ```text
 HiC-Nap = restartable chunk-processing prototype / engine
-microC-pipeline = final integrated production-facing project
+Wulf3C = final integrated production-facing project
 ```
 
-Key HiC-Nap concepts to bring into `microC-pipeline`:
+Key HiC-Nap concepts to bring into `Wulf3C`:
 
 - FASTQ chunking for large datasets
 - Per-chunk status tracking
@@ -101,7 +101,7 @@ Planned or completed tasks:
 Expected status after this milestone:
 
 ```text
-microC-pipeline is public-safe and useful as a documented legacy Slurm script.
+Wulf3C is public-safe and useful as a documented legacy Slurm script.
 ```
 
 ## Milestone v0.3.0: project structure and identity
@@ -121,7 +121,7 @@ Completed project structure and identity tasks:
 
 Remaining or future tasks, not completed in this milestone:
 
-- [ ] Add a modern executable entrypoint, for example `bin/microc-pipeline`.
+- [ ] Add a modern executable entrypoint, for example `bin/wulf3c`.
 - [ ] Define GitHub repository topics and description.
 - [ ] Make a final production engine choice if project ownership gives that direction.
 - [ ] Implement the modern pipeline engine.
@@ -140,7 +140,7 @@ Goal: remove hard-coded sample naming and path assumptions for one Micro-C sampl
 
 Completed tasks:
 
-- [x] Add the `bin/microc-pipeline` executable entrypoint.
+- [x] Add the `bin/wulf3c` executable entrypoint.
 - [x] Add a single-sample YAML config format.
 - [x] Add `config/example.single-sample.yaml` without restriction enzyme settings.
 - [x] Add support for explicit `fastq.r1` and `fastq.r2` paths.
@@ -411,4 +411,4 @@ The project should grow in two layers:
    - sensible examples
    - documentation that makes the pipeline useful to other researchers
 
-The immediate next step after v0.1.1 is to preserve the cleaned legacy script while designing the modern engine. The most valuable future work is to bring the restartable chunk-processing model from HiC-Nap into `microC-pipeline` and make it the foundation of v1.0.0.
+The immediate next step after v0.1.1 is to preserve the cleaned legacy script while designing the modern engine. The most valuable future work is to bring the restartable chunk-processing model from HiC-Nap into `Wulf3C` and make it the foundation of v1.0.0.

--- a/microc_pipeline/cli.py
+++ b/microc_pipeline/cli.py
@@ -1,4 +1,4 @@
-"""CLI for the v0.5.0 config-driven single-sample Micro-C runner."""
+"""CLI for the Wulf3C config-driven single-sample Micro-C runner."""
 
 from __future__ import annotations
 
@@ -17,8 +17,8 @@ from .runner import (
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="microc-pipeline",
-        description="Lightweight config-driven single-sample Micro-C preprocessing runner.",
+        prog="wulf3c",
+        description="Wulf3C lightweight config-driven single-sample Micro-C preprocessing runner.",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 


### PR DESCRIPTION
### Motivation
- Introduce the preferred public CLI `bin/wulf3c` and clarify the project identity as Wulf3C while preserving a backward-compatible `bin/microc-pipeline` wrapper.
- Align the CLI program name and public documentation to the new branding so examples and help text use `bin/wulf3c`.
- Record the rename in `CHANGELOG.md` while making clear that `assay: microc` and the standardized output contract are unchanged.

### Description
- Added a new executable `bin/wulf3c` as the primary entrypoint and converted `bin/microc-pipeline` into a deprecated compatibility wrapper with an updated docstring.
- Updated the CLI metadata in `microc_pipeline/cli.py` to use `prog="wulf3c"` and adjusted the description, and replaced occurrences of `bin/microc-pipeline` with `bin/wulf3c` across `README.md`, `config/README.md`, and docs under `docs/`.
- Updated `CHANGELOG.md`, `docs/design.md`, `docs/roadmap.md`, and `docs/outputs.md` to reflect the Wulf3C name and example command changes; no changes were made to pipeline runtime logic or behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a19e4a9e4832787d11ca4b8bce1e4)